### PR TITLE
Adding VW JNI external models.

### DIFF
--- a/aloha-cli/src/test/scala/com/eharmony/aloha/cli/CliTest.scala
+++ b/aloha-cli/src/test/scala/com/eharmony/aloha/cli/CliTest.scala
@@ -45,6 +45,8 @@ class CliTest extends TestWithIoCapture(CliTest) {
               |        numeric id of the model.
               |  --vw-args <value>
               |        arguments to vw
+              |  --external
+              |        link to a binary VW model rather than embedding it inline in the aloha model.
               |  --num-missing-thresh <value>
               |        number of missing features to allow before returning a 'no-prediction'.
               |  --note <value>

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/Cli.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/Cli.scala
@@ -25,6 +25,7 @@ object Cli {
         id: Long = 0,
         name: String = "",
         vwArgs: Option[String] = None,
+        externalModel: Boolean = false,
         numMissingThreshold: Option[Int] = None,
         notes: Vector[String] = Vector.empty,
         splineMin: Option[Double] = None,
@@ -33,10 +34,10 @@ object Cli {
 
     def main(args: Array[String]) {
         cliParser.parse(args, Config()) match {
-            case Some(Config(spec, model, id, name, vwArgs, numMissingThresh, notesList, min, max, knots)) =>
+            case Some(Config(spec, model, id, name, vwArgs, externalModel, numMissingThresh, notesList, min, max, knots)) =>
                 val spline = for (n <- min; x <- max; k <- knots) yield ConstantDeltaSpline(n, x, k)
                 val notes = Option(notesList) filter {_.nonEmpty}
-                val jsonAst = VwJniModel.json(spec, model, ModelId(id, name), vwArgs, numMissingThresh, notes, spline)
+                val jsonAst = VwJniModel.json(spec, model, ModelId(id, name), vwArgs, externalModel, numMissingThresh, notes, spline)
                 println(jsonAst.compactPrint)
             case None => // Will be taken care of by scopt.
         }
@@ -60,6 +61,9 @@ object Cli {
             opt[String]("vw-args") action { (x, c) =>
                 c.copy(vwArgs = Some(x))
             } text "arguments to vw" optional()
+            opt[Unit]("external") action { (x, c) =>
+                c.copy(externalModel = true)
+            } text "link to a binary VW model rather than embedding it inline in the aloha model." optional()
             opt[Int]("num-missing-thresh") action { (x, c) =>
                 c.copy(numMissingThreshold = Option(x))
             } text "number of missing features to allow before returning a 'no-prediction'." optional()

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
@@ -73,7 +73,7 @@ class VwJniModelJsonTest {
              |  }
              |}
            """).stripMargin.parseJson
-      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), None, Some(Seq("This is a note")))
+      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, Some(Seq("This is a note")))
       assertEquals(expected, actual)
   }
 
@@ -102,7 +102,7 @@ class VwJniModelJsonTest {
              |}
            """).stripMargin.parseJson
 
-      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), None, None, Some(cds))
+      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, None, Some(cds))
       assertEquals(expected, actual)
   }
 
@@ -132,7 +132,7 @@ class VwJniModelJsonTest {
              |  }
              |}
            """).stripMargin.parseJson
-      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), None, Some(Seq("This is a note")), Some(cds))
+      val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, Some(Seq("This is a note")), Some(cds))
       assertEquals(expected, actual)
   }
 }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -240,8 +240,14 @@ class VwJniModelTest {
         val tmpUrlPath = tmpUrl.getName.getPath
         vfs2.FileUtil.copyContent(url(VwModelPath), tmpUrl)
         val tmp = model[Float](extJson(tmpUrl.toString))
-        assertTrue("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(TmpDir))
-        assertFalse("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(tmpUrlPath))
+        val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
+        tmp.finalVwParams match {
+            case file(tmpFile) =>
+                assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
+                assertTrue("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(TmpDir))
+                assertFalse("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(tmpUrlPath))
+            case _ => fail("Should have a temp file location")
+        }
     }
 
     @Test def testRamUrlCopiesToLocal(): Unit = {
@@ -249,8 +255,15 @@ class VwJniModelTest {
         val ramUrlPath = ramUrl.getName.getPath
         vfs2.FileUtil.copyContent(url(VwModelPath), ramUrl)
         val ram = model[Float](extJson(ramUrl.toString))
-        assertTrue("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(TmpDir))
-        assertFalse("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(ramUrlPath))
+
+        val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
+        ram.finalVwParams match {
+            case file(tmpFile) =>
+                assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
+                assertTrue("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(TmpDir))
+                assertFalse("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(ramUrlPath))
+            case _ => fail("Should have a temp file location")
+        }
     }
 
     @Test def testGzFileUrlCopiesToLocal(): Unit = {
@@ -265,7 +278,14 @@ class VwJniModelTest {
 
         // Show that we can take gzipped URLs and that they are copied to a local temp file.
         val gz = model[Float](extJson(gzUrl.toString))
-        assertTrue("'gz' URLs should copy VW model to temp directory.", gz.finalVwParams.contains(TmpDir))
+
+        val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
+        gz.finalVwParams match {
+            case file(tmpFile) =>
+                assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
+                assertTrue("'gz' URLs should copy VW model to temp directory.", gz.finalVwParams.contains(TmpDir))
+            case _ => fail("Should have a temp file location")
+        }
     }
 
     @Test def testBzip2FileUrlCopiesToLocal(): Unit = {
@@ -280,9 +300,15 @@ class VwJniModelTest {
 
         // Show that we can take zipped URLs and that they are copied to a local temp file.
         val bz2 = model[Float](extJson(bz2Url.toString))
-        assertTrue("'zip' URLs should copy VW model to temp directory.", bz2.finalVwParams.contains(TmpDir))
-    }
 
+        val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
+        bz2.finalVwParams match {
+            case file(tmpFile) =>
+                assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
+                assertTrue("'zip' URLs should copy VW model to temp directory.", bz2.finalVwParams.contains(TmpDir))
+            case _ => fail("Should have a temp file location")
+        }
+    }
 
     @Test def testExternalModel(): Unit = {
         val b64Json =

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -256,7 +256,6 @@ class VwJniModelTest {
     @Test def testGzFileUrlCopiesToLocal(): Unit = {
         val localUrl = url(VwModelPath)
         val gzUrl = url("gz://" + VwModelPath + ".gz")
-        val gzUrlPath = gzUrl.getName.getPath
         vfs2.FileUtil.copyContent(localUrl, gzUrl)
 
         // Assert that gzipping actually transformed the file.
@@ -268,6 +267,22 @@ class VwJniModelTest {
         val gz = model[Float](extJson(gzUrl.toString))
         assertTrue("'gz' URLs should copy VW model to temp directory.", gz.finalVwParams.contains(TmpDir))
     }
+
+    @Test def testBzip2FileUrlCopiesToLocal(): Unit = {
+        val localUrl = url(VwModelPath)
+        val bz2Url = url("bz2://" + VwModelPath + ".bz2")
+        vfs2.FileUtil.copyContent(localUrl, bz2Url)
+
+        // Assert that zipping actually transformed the file.
+        assertFalse("BZip2ing should modify file",
+            Base64.encodeBase64(vfs2.FileUtil.getContent(localUrl)) ==
+                Base64.encodeBase64(vfs2.FileUtil.getContent(url(VwModelPath + ".bz2"))))
+
+        // Show that we can take zipped URLs and that they are copied to a local temp file.
+        val bz2 = model[Float](extJson(bz2Url.toString))
+        assertTrue("'zip' URLs should copy VW model to temp directory.", bz2.finalVwParams.contains(TmpDir))
+    }
+
 
     @Test def testExternalModel(): Unit = {
         val b64Json =


### PR DESCRIPTION
The CLI for creating VW models uses the `--external` flag to determine whether an embedded or externalized model should be produced.  Remember that when using `--external`, the location refers to the location at model instantiation time, not model JSON creation time.

Look at the unit tests.  The 'modelUrl' field in the JSON for VwJniModel can have many different protocols.  The following VFS file systems will not cause the content to be copied to a local temp file:
- [File](https://commons.apache.org/proper/commons-vfs/filesystems.html#Local_Files)
- [RES](https://commons.apache.org/proper/commons-vfs/filesystems.html#res)
- No Protocol (_same as [File](https://commons.apache.org/proper/commons-vfs/filesystems.html#Local_Files) VFS file system_)

The following are known to copy to local: 
- [Temp](https://commons.apache.org/proper/commons-vfs/filesystems.html#Temporary_File)
- [RAM](https://commons.apache.org/proper/commons-vfs/filesystems.html#ram)
- [_GZIP_ and _BZIP2_](https://commons.apache.org/proper/commons-vfs/filesystems.html#gzip_and_bzip2)

The following file systems should copy to local but have not been tested: 
- FTP
- FTPS
- HDFS
- HTTP
- HTTPS
- Jar
- SFTP
- Tar
- Zip 
