### PR TITLE
7-Clean up Scala Docs

### DIFF
--- a/aloha-core/src/main/scala/com/eharmony/aloha/dataset/csv/CsvRowCreator.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/dataset/csv/CsvRowCreator.scala
@@ -16,7 +16,8 @@ import scala.util.{Failure, Success, Try}
  * @param features a representation of the features used to generate the row ouput.
  * @param headers note that the dimensionality of this vector is equal to the dimensionality of the output vector
  *                produced by features rather than the number of features used to produce the vector.  This is because
- *                categorical variables can be expanded in different ways based on the [[Encoding]] used.
+ *                categorical variables can be expanded in different ways based on the
+ *                [[com.eharmony.aloha.dataset.csv.encoding.Encoding]] used.
  * @param separator the field separator
  * @tparam A the input type that is transformed into CSV output.
  */

--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelFactory.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelFactory.scala
@@ -104,7 +104,8 @@ case class ModelFactory(modelParsers: ModelParser*) extends JsValuePimpz {
       * @param json JSON to be parsed and translated to a model.
       * @tparam A input type of the resulting model
       * @tparam B output type of the resulting model
-      * @return A [[scala.util.Try]] statement potentially containing a subtype of Model.
+      * @return A [[http://scala-lang.org/api/current/#scala.util.Try scala.util.Try]] statement potentially containing
+      *         a subtype of Model.
       */
     def getModel[A: RefInfo, B: RefInfo: JsonReader: ScoreConverter](json: JsValue, semantics: Option[Semantics[A]] = None): Try[Model[A, B]] =
         getModelAndInfo[A, B](json, semantics).map(_.model)

--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/TypedModelFactory.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/TypedModelFactory.scala
@@ -17,9 +17,9 @@ import com.eharmony.aloha.io.multiple.{ SequenceMultipleReadable, MultipleAlohaR
  *
  * Note that there are essentially three factory interfaces associated with this factory.  Those are calling:
  *
- * 1.   methods from [[com.eharmony.aloha.io.AlohaReadable]]: This gives back a scala.util.Try[ [[com.eharmony.aloha.models.Model]] ] instance.
- * 1.   methods in the model value.  This gives back a scala.util.Try of an instance of M[A, B].
- * 1.   methods in the modelAndInfo value.  This gives back a scala.util.Try of an instance of [[com.eharmony.aloha.factory.ModelInfo]][ M[A, B] ].
+ 1.   methods from [[com.eharmony.aloha.io.AlohaReadable]]: This gives back a scala.util.Try[ [[com.eharmony.aloha.models.Model]] ] instance.
+ 1.   methods in the model value.  This gives back a scala.util.Try of an instance of M[A, B].
+ 1.   methods in the modelAndInfo value.  This gives back a scala.util.Try of an instance of [[com.eharmony.aloha.factory.ModelInfo]][ M[A, B] ].
  *
  * From Scala, it is recommended to use function from methods 2 or 3 above as more type information is retained.
  *
@@ -77,7 +77,8 @@ import com.eharmony.aloha.io.multiple.{ SequenceMultipleReadable, MultipleAlohaR
  * @param evidence$1 reflection information about type parameter A
  * @param evidence$2 reflection information about type parameter B
  * @param evidence$3 a way to read a variable of type B from JSON
- * @param evidence$4 a way to convert an instance of type B into a [[com.eharmony.aloha.score.Scores.Score]]
+ * @param evidence$4 a way to convert an instance of type B into a
+ *                   [[https://github.com/eHarmony/aloha-proto/blob/master/src/main/proto/com.eharmony.aloha.score.Scores.proto com.eharmony.aloha.score.Scores.Score]]
  * @tparam A the input type of models created by this factory
  * @tparam B the output type of models created by this factory
  * @tparam M the kind (as in higher kind) of models created.  This represents the greatest lower bound of all of the

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/ErrorSwallowingModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/ErrorSwallowingModel.scala
@@ -22,8 +22,8 @@ import com.eharmony.aloha.factory.ex.AlohaFactoryException
   * should be:
   *
   - com.eharmony.aloha.models.ErrorSwallowingModel.errorMsg(ex)
-  - [[com.eharmony.aloha.models.ErrorSwallowingModel.ExMsgThrewMsg]]
-  - [[com.eharmony.aloha.models.ErrorSwallowingModel.StackTraceOmitted]]
+  - ''com.eharmony.aloha.models.ErrorSwallowingModel.ExMsgThrewMsg''
+  - ''com.eharmony.aloha.models.ErrorSwallowingModel.StackTraceOmitted''
   *
   * If the exception that is caught is a [[com.eharmony.aloha.semantics.SemanticsUdfException]], then
   * 3 additional fields are added to the end of the errors list in indices 3, 4, 5:

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/reg/RegressionModelValueToTupleConversions.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/reg/RegressionModelValueToTupleConversions.scala
@@ -14,7 +14,7 @@ import scala.language.implicitConversions
   * when prefixed will yield Iterable(("intercept", 1234.0))
   *
   * {{{
-  * {
+  *   * {
   *   "modelType": "Regression",
   *   "modelId": {"id": 0, "name": ""},
   *   "features": {
@@ -23,6 +23,8 @@ import scala.language.implicitConversions
   *   },
   *   ...
   * }
+  * }}}
+  *
   */
 // TODO, think about making this
 trait RegressionModelValueToTupleConversions {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/tree/decision/nodes.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/tree/decision/nodes.scala
@@ -15,14 +15,14 @@ sealed trait Node[-A, +B] extends Tree[B, immutable.IndexedSeq, Node[A, B]] {
     /** Find the deepest node in the tree possible, given the data (in v), on which to branch.  Progress down the
       * decision tree until no further progress can be made and return the node.
       *
-      * [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] when a leaf is reached or
-      * [[scala.util.Right]][[(com.eharmony.aloha.models.tree.decision.InteriorNode, Option[String])]]
-      * when progress down the tree was stopped prior to reaching a leaf node.  The node in the tuple is the last node
-      * in which we could make a successful choice.
+      * [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] when a leaf is reached or
+      * [[scala.Left]] [''InteriorNodeResult''] when progress down the tree
+      * was stopped prior to reaching a leaf node. The node in the ''InteriorNodeResult''
+      * is the last node in which we could make a successful choice.
       * @param v the input whose data is used to branch down the decision tree.
-      * @return either a [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] representing a
-      *         leaf node in the tree or a [[scala.util.Left]] with a node where no further progress down the tree
-      *         could be made and an optional sequence of log messages.
+      * @return either a [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] representing a leaf node
+      *         in the tree or a [[scala.Left]] with a node where no further progress down the tree could be made and
+      *         an optional sequence of log messages.
       */
     def getNode(v: A): Either[InteriorNodeResult[A, B], Leaf[B]]
 }
@@ -55,15 +55,15 @@ object Node {
 
     /** Progress down the decision tree until no further progress can be made and return the node.
       *
-      * [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] when a leaf is reached or
-      * [[scala.util.Right]][[(com.eharmony.aloha.models.tree.decision.InteriorNode, Option[String])]]
-      * when progress down the tree was stopped prior to reaching a leaf node.  The node in the tuple is the last node
-      * in which we could make a successful choice.
+      * [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] when a leaf is reached or
+      * [[scala.Right]] [''InteriorNodeResult''] when progress down the tree
+      * was stopped prior to reaching a leaf node.  The node in the ''InteriorNodeResult''
+      * is the last node in which we could make a successful choice.
       * @param n a node from which to start the search.
       * @param v the input whose data is used to branch down the decision tree.
-      * @return either a [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] representing a
-      *         leaf node in the tree or a [[scala.util.Left]] with a node where no further progress down the tree
-      *         could be made and an optional sequence of log messages.
+      * @return either a [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] representing a leaf
+      *         node in the tree or a [[scala.Left]] with a node where no further progress down the tree could be made
+      *         and an optional sequence of log messages.
       */
     private[decision] def getNode[A, B](n: Node[A, B], v: A): Either[InteriorNodeResult[A, B], Leaf[B]] = n match {
         case leaf: Leaf[B] => Right(leaf)
@@ -85,10 +85,10 @@ object Node {
   */
 case class Leaf[+B](value: B) extends Node[Any, B] {
 
-    /** Return this node wrapped in a [[scala.util.Right]].
+    /** Return this node wrapped in a [[scala.Right]].
       *
       * @param v irrelevant input data. (Not used)
-      * @return either a [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] this node.
+      * @return either a [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] this node.
       */
     def getNode(v: Any) = Right(this)
 
@@ -105,14 +105,14 @@ case class InteriorNode[-A, +B](
 
     /** Progress down the decision tree until no further progress can be made and return the node.
       *
-      * [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] when a leaf is reached or
-      * [[scala.util.Right]][[(com.eharmony.aloha.models.tree.decision.InteriorNode, Option[String])]]
-      * when progress down the tree was stopped prior to reaching a leaf node.  The node in the tuple is the last node
-      * in which we could make a successful choice.
+      * [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] when a leaf is reached or
+      * [[scala.Right]] [''InteriorNodeResult''] when progress down the tree
+      * was stopped prior to reaching a leaf node. The node in the tuple is the last node in which we could make a
+      * successful choice.
       * @param v the input whose data is used to branch down the decision tree.
-      * @return either a [[scala.util.Right]][[com.eharmony.aloha.models.tree.decision.Leaf]] representing a
-      *         leaf node in the tree or a [[scala.util.Left]] with a node where no further progress down the tree
-      *         could be made and an optional sequence of log messages.
+      * @return either a [[scala.Right]] [ [[com.eharmony.aloha.models.tree.decision.Leaf]] ] representing a leaf node
+      *         in the tree or a [[scala.Left]] with a node where no further progress down the tree could be made and
+      *         an optional sequence of log messages.
       */
     def getNode(v: A): Either[InteriorNodeResult[A, B], Leaf[B]] = Node.getNode(this, v)
 }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/score/conversions/scoreConversions.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/score/conversions/scoreConversions.scala
@@ -66,7 +66,8 @@ object RelaxedConversions extends BasicTypeScoreConversions[Option] {
 
     /** Get the score.  The Option tells the score exists.  The Right in the embedded Either contains the actual
       * score and the Left contains the type that actually exists in the
-      * [[com.eharmony.aloha.score.Scores.Score]] if querying the wrong type.
+      * [[https://github.com/eHarmony/aloha-proto/blob/master/src/main/proto/com.eharmony.aloha.score.Scores.proto com.eharmony.aloha.score.Scores.Score]]
+      * if querying the wrong type.
       * @param s the score
       * @tparam A the type to which the score should be converted.
       * @return

--- a/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsPlugin.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsPlugin.scala
@@ -13,8 +13,8 @@ import com.eharmony.aloha.reflect.{RefInfoOps, RefInfo}
   */
 trait CompiledSemanticsPlugin[A] {
     /**
-      * @return a [[scala.reflect.runtime.universe.TypeTag]] for input type A.
-      */
+      * @return [[com.eharmony.aloha.reflect.RefInfo]] containing reflection information about input type A.
+     */
     def refInfoA: RefInfo[A]
 
     /** Generate the code necessary to compile into a function.

--- a/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/plugin/csv/CompiledSemanticsCsvPlugin.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/plugin/csv/CompiledSemanticsCsvPlugin.scala
@@ -12,7 +12,7 @@ import scala.annotation.varargs
 case class CompiledSemanticsCsvPlugin(colNamesToTypes: Map[String, CsvTypes.CsvType] = Map.empty) extends CompiledSemanticsPlugin[CsvLine] {
 
    /**
-     * @return a [[scala.reflect.runtime.universe.TypeTag]] for input type A.
+     * A [[com.eharmony.aloha.reflect.RefInfo]] containing reflection information about input type A.
      */
     val refInfoA = RefInfo[CsvLine]
 

--- a/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/plugin/proto/CompiledSemanticsProtoPlugin.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/semantics/compiled/plugin/proto/CompiledSemanticsProtoPlugin.scala
@@ -47,9 +47,10 @@ import com.eharmony.aloha.util.EitherHelpers
  * }}}
  * @param dereferenceAsOptional Whether to treat dereferenced list variables as an Option.  If '''true''' treat the
  *                              return value of a dereference operation as an Option.  This removes the possibility
- *                              of a [[java.lang.IndexOutOfBoundsException]] being thrown.  Instead, it will silently
- *                              return None.  If '''false''', treat the returned value as a required field and don't
- *                              do any index checking.  The default value is '''true'''.
+ *                              of a [[http://docs.oracle.com/javase/7/docs/api/java/lang/IndexOutOfBoundsException.html java.lang.IndexOutOfBoundsException]]
+ *                              being thrown.  Instead, it will silently return None.  If '''false''', treat the
+ *                              returned value as a required field and don't do any index checking.  The default
+ *                              value is '''true'''.
  * @param refInfoA
  * @tparam A a type of generated protocol buffer message.
  */

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -44,7 +44,8 @@ import scala.util.{Failure, Success, Try}
  * @param namespaces mapping from namespace name to indices of features that will be placed in the namespace
  * @param finalizer a function that transforms the native VW output type (Float) to B
  * @param numMissingThreshold A threshold dictating how many missing features to allow before making the
- *                            prediction fail.  See [[com.eharmony.aloha.models.reg.RegressionFeatures.numMissingThreshold]]
+ *                            prediction fail.  See ''com.eharmony.aloha.models.reg.RegressionFeatures.numMissingThreshold''
+ *                            in aloha-core.
  * @param scb a score converter
  * @tparam A model input type
  * @tparam B model output type


### PR DESCRIPTION
No code change.  Just scaladoc. Cleaned up scaladoc warnings except the 7 spurious warnings: 

> 'warning: Variable xyz undefined in comment'

These are due to a scaladoc bug.  See issue #7 for more information on the bug.
