### PR TITLE
This should address issue 32

### DIFF
--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
@@ -2,6 +2,8 @@ package com.eharmony.aloha.models.vw.jni
 
 import com.eharmony.aloha.factory.Formats.listMapFormat
 import com.eharmony.aloha.id.ModelId
+import com.eharmony.aloha.io.fs.FsType
+import com.eharmony.aloha.io.fs.FsType.FsType
 import com.eharmony.aloha.io.fs.{FsInstance, FsType}
 import com.eharmony.aloha.models.reg.ConstantDeltaSpline
 import com.eharmony.aloha.models.reg.json.{Spec, SpecJson}
@@ -31,7 +33,7 @@ trait VwJniModelJson extends SpecJson {
      *               single string by imploding the list with a " " separator or it is one string.  If None,
      * @param model an optional model.  This is a base64 encoded representation of a native VW binary model.
      */
-    protected[this] case class Vw(model: Either[String, FsInstance], params: Option[Either[Seq[String], String]] = Option(Right("")))
+    protected[this] case class Vw(model: Either[(String, FsType), FsInstance], params: Option[Either[Seq[String], String]] = Option(Right("")))
 
     /**
      * Note that as is, this declaration will cause a compiler warning:
@@ -88,7 +90,7 @@ trait VwJniModelJson extends SpecJson {
 
             val model = (modelVal, modelUrlVal, fsType) match {
                 case (None, Some(u), t)    => Right(FsInstance.fromFsType(t)(u))
-                case (Some(m), None, _)    => Left(m)
+                case (Some(m), None, t)    => Left((m, t))
                 case (Some(m), Some(u), _) => throw new DeserializationException("Exactly one of 'model' and 'modelUrl' should be supplied. Both supplied: " + json.compactPrint)
                 case (None, None, _)       => throw new DeserializationException("Exactly one of 'model' and 'modelUrl' should be supplied. Neither supplied: " + json.compactPrint)
             }
@@ -104,9 +106,7 @@ trait VwJniModelJson extends SpecJson {
         override def write(v: Vw) = {
             val model = v.model match {
                 case Left(m) =>
-                    Seq("model" -> JsString(m))
-                case Right(fsInstance) if fsInstance.fsType == FsType.vfs2 =>
-                    Seq("modelUrl" -> JsString(fsInstance.descriptor))
+                    Seq("model" -> JsString(m._1), "via" -> JsString(m._2.toString))
                 case Right(fs) =>
                     Seq("modelUrl" -> JsString(fs.descriptor), "via" -> JsString(fs.fsType.toString))
             }

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -164,7 +164,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
             finalizer: Double => B,
             numMissingThreshold: Option[Int],
             spline: Option[Spline],
-            fsType: FsType = FsType.vfs2)(implicit scb: ScoreConverter[B]): VwJniModel[A, B] = {
+            fsType: FsType)(implicit scb: ScoreConverter[B]): VwJniModel[A, B] = {
         val allocatedModel = allocateModel(modelId.getId(), b64EncodedVwModel)
         val vwModel = FsInstance.fromFsType(fsType)(allocatedModel.getCanonicalPath)
         new VwJniModel[A, B](modelId, vwModel, vwParams, featureNames, featureFunctions,
@@ -211,7 +211,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
                         val defaultNs = (indices.keySet -- (Set.empty[String] /: nssRaw)(_ ++ _._2)).flatMap(indices.get).toList
 
                         vw.vw.model match {
-                            case Left(model) => VwJniModel(vw.modelId, model, vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline)
+                            case Left(model) => VwJniModel(vw.modelId, model._1, vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline, model._2)
                             case Right(url)  => VwJniModel(vw.modelId, url, vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline)
                         }
                 }
@@ -390,7 +390,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
         val vwObj = if (externalModel) Vw(Right(model), vwParams)
                     else {
                         val b64Model = VwJniModel.readBinaryVwModelToB64String(model.inputStream)
-                        Vw(Left(b64Model), vwParams)
+                        Vw(Left((b64Model, model.fsType)), vwParams)
                     }
 
         VwJNIAst(VwJniModel.parser.modelType, id, features, vwObj, ns, numMissingThreshold, notes, spline).toJson

--- a/aloha-vw-jni/src/test/resources/com/eharmony/aloha/models/vw/jni/good.logistic.aloha.js
+++ b/aloha-vw-jni/src/test/resources/com/eharmony/aloha/models/vw/jni/good.logistic.aloha.js
@@ -8,6 +8,7 @@
     {"name": "personal_features", "features": [ "height_mm" ] }
   ],
   "vw": {
+    "via": "vfs2",
     "params": [
       "--quiet",
       "-t"

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
@@ -191,6 +191,7 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |    "personal_features": [ "height_mm" ]
                    |  },
                    |  "vw": {
+                   |    "via": "vfs2",
                    |    "params": "--quiet -t",
                    |    "model": """".stripMargin.trim + base64EncodedModelString + """"
                    |  }
@@ -228,6 +229,7 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |    "personal_features": [ "height_mm" ]
                    |  },
                    |  "vw": {
+                   |    "via": "vfs2",
                    |    "params": "--quiet -t",
                    |    "modelUrl": """".stripMargin.trim + url.getName.getPath + """"
                    |  }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
@@ -44,6 +44,7 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
+             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim +  base64EncodedModelString + """"
              |  }
@@ -69,6 +70,7 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
+             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }
@@ -97,6 +99,7 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
+             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }
@@ -128,6 +131,7 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
+             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -7,6 +7,7 @@ import com.eharmony.aloha.FileLocations
 import com.eharmony.aloha.factory.JavaJsonFormats._
 import com.eharmony.aloha.factory.ModelFactory
 import com.eharmony.aloha.id.ModelId
+import com.eharmony.aloha.io.fs.FsType
 import com.eharmony.aloha.models.TypeCoercion
 import com.eharmony.aloha.reflect.RefInfo
 import com.eharmony.aloha.score.conversions.ScoreConverter
@@ -144,7 +145,8 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None
+                None,
+                FsType.vfs2
             )
             fail("should throw IllegalArgumentException")
         }
@@ -169,7 +171,8 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None
+                None,
+                FsType.vfs2
             )
             fail("should throw IllegalArgumentException")
         }
@@ -194,7 +197,8 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None
+                None,
+                FsType.vfs2
             )
             fail("should throw IllegalArgumentException")
         }


### PR DESCRIPTION
This should address the issue with using Vfs2 as the only way to read embedded models.  @deaktator please review this.  Note that I didn't add any tests for this I just made all the current tests pass.  I also forced the writing of the via flag in all models to make the model more explicit but I did not remove Vfs2 as the default when reading if via is absent.
