### PR TITLE
Attempt to make cross machine serialization work for VwJniModel

### DIFF
--- a/aloha-core/src/main/scala/com/eharmony/aloha/io/fs/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/io/fs/package.scala
@@ -33,6 +33,7 @@ package object fs {
         def inputStream: InputStream
         def outputStream(append: Boolean = false): OutputStream
         def localFile: Option[File]
+        def isLocal = localFile.isDefined
         def descriptor: String
     }
 

--- a/aloha-core/src/main/scala/com/eharmony/aloha/io/fs/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/io/fs/package.scala
@@ -33,7 +33,7 @@ package object fs {
         def inputStream: InputStream
         def outputStream(append: Boolean = false): OutputStream
         def localFile: Option[File]
-        def isLocal = localFile.isDefined
+        def existsLocally = localFile exists (_.exists)
         def descriptor: String
     }
 

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
@@ -31,7 +31,8 @@ trait VwJniModelJson extends SpecJson {
      * warning.
      * @param params VW initialization parameters.  This is either a sequence of parameters that will be made into a
      *               single string by imploding the list with a " " separator or it is one string.  If None,
-     * @param model an optional model.  This is a base64 encoded representation of a native VW binary model.
+     * @param model an optional model.  This is a base64 encoded representation of a native VW binary model or a VFS
+     *              url stating where to get that model.
      */
     protected[this] case class Vw(model: Either[String, FsInstance], params: Option[Either[Seq[String], String]] = Option(Right("")))
 

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJNIModelJson.scala
@@ -1,9 +1,8 @@
 package com.eharmony.aloha.models.vw.jni
 
-import com.eharmony.aloha.factory.Formats.listMapFormat
-import com.eharmony.aloha.id.ModelId
-import com.eharmony.aloha.io.fs.FsType
-import com.eharmony.aloha.io.fs.FsType.FsType
+import com.eharmony.aloha.factory.ScalaJsonFormats.listMapFormat
+import com.eharmony.aloha.id.ModelIdentity
+import com.eharmony.aloha.id.ModelIdentityJson.modelIdentityJsonFormat
 import com.eharmony.aloha.io.fs.{FsInstance, FsType}
 import com.eharmony.aloha.models.reg.ConstantDeltaSpline
 import com.eharmony.aloha.models.reg.json.{Spec, SpecJson}
@@ -11,6 +10,8 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.collection.immutable.ListMap
+
+
 
 /**
  * Components of the JSON protocol for VwJniModel
@@ -31,10 +32,9 @@ trait VwJniModelJson extends SpecJson {
      * warning.
      * @param params VW initialization parameters.  This is either a sequence of parameters that will be made into a
      *               single string by imploding the list with a " " separator or it is one string.  If None,
-     * @param model an optional model.  This is a base64 encoded representation of a native VW binary model or a VFS
-     *              url stating where to get that model.
+     * @param modelSource A [[VwJniModelSource]]
      */
-    protected[this] case class Vw(model: Either[String, FsInstance], params: Option[Either[Seq[String], String]] = Option(Right("")))
+    protected[this] case class Vw(modelSource: VwJniModelSource, params: Option[Either[Seq[String], String]] = Option(Right("")))
 
     /**
      * Note that as is, this declaration will cause a compiler warning:
@@ -61,7 +61,7 @@ trait VwJniModelJson extends SpecJson {
      */
     protected[this] case class VwJNIAst(
         modelType: String,
-        modelId: ModelId,
+        modelId: ModelIdentity,
         features: ListMap[String, Spec],
         vw: Vw,
         namespaces: Option[ListMap[String, Seq[String]]] = Some(ListMap.empty),
@@ -69,9 +69,14 @@ trait VwJniModelJson extends SpecJson {
         notes: Option[Seq[String]] = None,
         spline: Option[ConstantDeltaSpline] = None)
 
-    protected[this] implicit object vwFormat extends RootJsonFormat[Vw] {
+    protected[this] implicit object VwFormat extends RootJsonFormat[Vw] {
         override def read(json: JsValue) = {
             val jso = json.asJsObject("Vw expected to be object")
+
+            val creationTime = jso.getFields("creationTime") match {
+                case Seq(JsNumber(t)) => t.toLongExact
+                case _                => System.currentTimeMillis()
+            }
 
             val modelVal = jso.getFields("model") match {
                 case Seq(JsString(m)) => Some(m)
@@ -89,29 +94,30 @@ trait VwJniModelJson extends SpecJson {
                 case _        => FsType.vfs2
             }
 
-            val model = (modelVal, modelUrlVal, fsType) match {
-                case (None, Some(u), t)    => Right(FsInstance.fromFsType(t)(u))
-                case (Some(m), None, _)    => Left(m)
+            val params = jso.getFields("params") match {
+                case Seq(p) => Option(p.convertTo[Either[Seq[String], String]])
+                case Nil    => None
+            }
+
+            val paramStr = params.map(_.fold(_.mkString(" "), identity)) getOrElse ""
+
+            val modelSource = (modelVal, modelUrlVal, fsType) match {
+                case (None, Some(u), t)    => ExternallyDefinedVwModelSource(FsInstance.fromFsType(t)(u), paramStr, creationTime)
+                case (Some(m), None, _)    => Base64EncodedBinaryVwModelSource(m, paramStr, creationTime)
                 case (Some(m), Some(u), _) => throw new DeserializationException("Exactly one of 'model' and 'modelUrl' should be supplied. Both supplied: " + json.compactPrint)
                 case (None, None, _)       => throw new DeserializationException("Exactly one of 'model' and 'modelUrl' should be supplied. Neither supplied: " + json.compactPrint)
             }
 
-            val vw = jso.getFields("params") match {
-                case Seq(params) => Vw(model, Option(params.convertTo[Either[Seq[String], String]]))
-                case Nil         => Vw(model)
-            }
-
-            vw
+            Vw(modelSource, params)
         }
 
         override def write(v: Vw) = {
-            val model = v.model match {
-                case Left(m) =>
-                    Seq("model" -> JsString(m))
-                case Right(fsInstance) if fsInstance.fsType == FsType.vfs2 =>
-                    Seq("modelUrl" -> JsString(fsInstance.descriptor))
-                case Right(fs) =>
-                    Seq("modelUrl" -> JsString(fs.descriptor), "via" -> JsString(fs.fsType.toString))
+            val model = v.modelSource match {
+                case Base64EncodedBinaryVwModelSource(b64, _, time) => Seq("model" -> JsString(b64),
+                                                                           "creationDate" -> JsNumber(time))
+                case ExternallyDefinedVwModelSource(fs, _,  time)   => Seq("modelUrl" -> JsString(fs.descriptor),
+                                                                           "creationDate" -> JsNumber(time),
+                                                                           "via" -> JsString(fs.fsType.toString))
             }
 
             val params = v.params.map(p => "params" -> p.toJson)

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -36,7 +36,7 @@ import scala.util.{Failure, Success, Try}
 /**
  * Model that delegates to a VW JNI model.
  * @param modelId a modelId
- * @param vwModel a FileObject pointing to a VW binary model.
+ * @param vwModel either the FsInstance pointing the the VW model or the Base64 encoded VW model.
  * @param vwParams VW parameters.  These are the same as the ones that would be passed on the command line,
  *                 directly to VW.
  * @param featureNames names of features (parallel to featureFunctions)
@@ -295,8 +295,8 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
 
     /**
      * This copies non-local-file content to a local temp file and returns the file name.  If
-     * @param modelId
-     * @param vwModel
+     * @param modelId the model ID
+     * @param vwModel either the FsInstance pointing the the VW model or the Base64 encoded VW model.
      * @return return Right if a temp file was created, Left(vwModel) otherwise.
      */
     private[jni] def copyModelToLocal(modelId: Long, vwModel: Either[FsInstance, String]): Either[File, File] = {

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -163,8 +163,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
             namespaces: List[(String, List[Int])],
             finalizer: Double => B,
             numMissingThreshold: Option[Int],
-            spline: Option[Spline],
-            fsType: FsType)(implicit scb: ScoreConverter[B]): VwJniModel[A, B] = {
+            spline: Option[Spline])(implicit scb: ScoreConverter[B]): VwJniModel[A, B] = {
         new VwJniModel[A, B](modelId, Right(b64EncodedVwModel), vwParams, featureNames, featureFunctions,
                              defaultNs, namespaces, finalizer, numMissingThreshold, spline)(scb)
     }
@@ -209,7 +208,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
                         val defaultNs = (indices.keySet -- (Set.empty[String] /: nssRaw)(_ ++ _._2)).flatMap(indices.get).toList
 
                         vw.vw.model match {
-                            case Left(model) => VwJniModel(vw.modelId, model._1, vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline, model._2)
+                            case Left(model) => VwJniModel(vw.modelId, model, vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline)
                             case Right(url)  => VwJniModel(vw.modelId, Left(url), vwParams, names, functions, defaultNs, nss, cf, vw.numMissingThreshold, vw.spline)
                         }
                 }
@@ -392,7 +391,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
         val vwObj = if (externalModel) Vw(Right(model), vwParams)
                     else {
                         val b64Model = VwJniModel.readBinaryVwModelToB64String(model.inputStream)
-                        Vw(Left((b64Model, model.fsType)), vwParams)
+                        Vw(Left(b64Model), vwParams)
                     }
 
         VwJNIAst(VwJniModel.parser.modelType, id, features, vwObj, ns, numMissingThreshold, notes, spline).toJson

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -36,7 +36,7 @@ import scala.util.{Failure, Success, Try}
 /**
  * Model that delegates to a VW JNI model.
  * @param modelId a modelId
- * @param vwModel either the FsInstance pointing the the VW model or the Base64 encoded VW model.
+ * @param vwModel either the FsInstance pointing to the VW model or the Base64 encoded VW model.
  * @param vwParams VW parameters.  These are the same as the ones that would be passed on the command line,
  *                 directly to VW.
  * @param featureNames names of features (parallel to featureFunctions)
@@ -295,7 +295,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
     /**
      * This copies non-local-file content to a local temp file and returns the file name.  If
      * @param modelId the model ID
-     * @param vwModel either the FsInstance pointing the the VW model or the Base64 encoded VW model.
+     * @param vwModel either the FsInstance pointing to the VW model or the Base64 encoded VW model.
      * @return return Right if a temp file was created, Left(vwModel) otherwise.
      */
     private[jni] def copyModelToLocal(modelId: Long, vwModel: Either[FsInstance, String]): Either[File, File] = {

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/VwJniModel.scala
@@ -283,7 +283,7 @@ object VwJniModel extends ParserProviderCompanion with VwJniModelJson with Loggi
      */
     private[jni] def copyModelToLocal(modelId: Long, vwModel: Either[String, FsInstance]): Either[File, File] = {
       vwModel match {
-        case Left(b64EncodedVwModel) => Left(allocateModel(modelId, b64EncodedVwModel))
+        case Left(b64EncodedVwModel) => Right(allocateModel(modelId, b64EncodedVwModel))
         case Right(fsInstance) => fsInstance.localFile.toLeft {
           val tmpFile = File.createTempFile(s"aloha.vw.$modelId.", ".model")
 

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/vwJniModelSources.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/vwJniModelSources.scala
@@ -1,0 +1,116 @@
+package com.eharmony.aloha.models.vw.jni
+
+import java.io.{File, FileOutputStream}
+
+import com.eharmony.aloha.io.fs.FsInstance
+import org.apache.commons.codec.binary.Base64
+import org.apache.commons.io.IOUtils
+import vw.VW
+
+
+object VwJniModelSource {
+    private[jni] val InitialRegressorPresent = """^(.*\s)?-i.*$"""
+}
+
+/**
+ * Needs to be Serializable
+ */
+sealed trait VwJniModelSource extends Serializable {
+    import VwJniModelSource._
+    def params: String
+    def timeMillis: Long
+    def copyContentToLocalIfNecessary(dest: File): Unit
+    def shouldDeleteLocalFile: Boolean
+
+    def localFile(modelId: Long): File
+
+    final def vwModel(modelId: Long): VW = {
+        val locFile = localFile(modelId)
+        val shouldDelete = shouldDeleteLocalFile
+
+        if (shouldDelete)
+            locFile.deleteOnExit()
+
+        copyContentToLocalIfNecessary(locFile)
+
+        val newParams = updatedVwModelParams(modelId)
+        val vw = new VW(newParams)
+
+        if (shouldDelete)
+            locFile.delete()
+
+        vw
+    }
+
+    def updatedVwModelParams(modelId: Long): String = {
+        val initialRegressorParam = s" -i ${localFile(modelId).getCanonicalPath} "
+
+        if (params matches InitialRegressorPresent)
+            throw new IllegalArgumentException(s"For model $modelId, initial regressor (-i) vw parameter supplied and model provided.")
+
+        initialRegressorParam + params
+    }
+
+    def tmpDir() = {
+        val t = File.createTempFile("abc123", "zyx987")
+        t.deleteOnExit()
+        val d = t.getParentFile.getCanonicalFile
+        t.delete()
+        d
+    }
+
+}
+
+final case class Base64EncodedBinaryVwModelSource(
+        b64EncodedBinaryVwModel: String,
+        params: String = "",
+        timeMillis: Long = System.currentTimeMillis()
+) extends VwJniModelSource {
+
+    def shouldDeleteLocalFile: Boolean = true
+
+    def localFile(modelId: Long): File = new File(tmpDir(), s"aloha.vw.$modelId.$timeMillis.model")
+
+    /**
+     * Takes the model ID and base64-encoded binary VW model and creates a temp file with the decoded data
+     * and returns the file handle.
+     * @return File object for the newly created temp file
+     */
+    def copyContentToLocalIfNecessary(dest: File): Unit = {
+        val decoded = Base64.decodeBase64(b64EncodedBinaryVwModel)
+
+        // Will overwrite the original file.  This is what we want because it's idempotent.
+        val fos = new FileOutputStream(dest)
+        try {
+            fos.write(decoded)
+        }
+        finally {
+            IOUtils closeQuietly fos
+        }
+    }
+}
+
+final case class ExternallyDefinedVwModelSource(
+        fsInstance: FsInstance,
+        params: String = "",
+        timeMillis: Long = System.currentTimeMillis()
+) extends VwJniModelSource {
+    def shouldDeleteLocalFile: Boolean = !fsInstance.isLocal
+
+    def localFile(modelId: Long): File =
+        fsInstance.localFile getOrElse new File(tmpDir(), s"aloha.vw.$modelId.$timeMillis.model")
+
+    def copyContentToLocalIfNecessary(dest: File): Unit = {
+        if (!fsInstance.isLocal) {
+            val is = fsInstance.inputStream
+            val os = new FileOutputStream(dest)
+            try {
+                IOUtils.copyLarge(is, os)
+            }
+            finally {
+                IOUtils.closeQuietly(is)
+                IOUtils.closeQuietly(os)
+            }
+        }
+    }
+}

--- a/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/vwJniModelSources.scala
+++ b/aloha-vw-jni/src/main/scala/com/eharmony/aloha/models/vw/jni/vwJniModelSources.scala
@@ -9,21 +9,61 @@ import vw.VW
 
 
 object VwJniModelSource {
+
+    /**
+     * A regular expression to check whether an initial regressor is present in the VW parameters.
+     */
     private[jni] val InitialRegressorPresent = """^(.*\s)?-i.*$"""
 }
 
 /**
- * Needs to be Serializable
+ *
+ * '''NOTE''': ''Must be Serializable.''
  */
 sealed trait VwJniModelSource extends Serializable {
     import VwJniModelSource._
+
+    /**
+     * The VW parameters.
+     * @return
+     */
     def params: String
+
+    /**
+     * This acts as a secondary piece of information on which the temp file names are based.  It doesn't
+     * need to be supplied because a default value is provided: the unixtime in milliseconds.
+     * @return
+     */
     def timeMillis: Long
+
+    /**
+     * The only effectful function to be provided by the subclass.  ''If necessary'', this function copies some
+     * representation of the VW model to the destination file.
+     * @param dest local destination where the VW binary model will be copied.
+     */
     def copyContentToLocalIfNecessary(dest: File): Unit
+
+    /**
+     * Indicates whether to attempt to delete the local file was it is determined it is no longer needed.
+     * If ''copyContentToLocalIfNecessary'' doesn't copy any content to the local disk, then this should
+     * return false.  If it does, this function should return true.
+     * @return
+     */
     def shouldDeleteLocalFile: Boolean
 
+    /**
+     * The local file that will eventually contain the binary VW model.
+     * @param modelId The numeric model identifier.
+     * @return
+     */
     def localFile(modelId: Long): File
 
+    /**
+     * Get the VW model.  If necessary, this will create a local file containing a VW binary model
+     * and will use the initial regressor flag to use it as the starting point to the model.
+     * @param modelId The numeric model identifier.
+     * @return
+     */
     final def vwModel(modelId: Long): VW = {
         val locFile = localFile(modelId)
         val shouldDelete = shouldDeleteLocalFile
@@ -42,6 +82,11 @@ sealed trait VwJniModelSource extends Serializable {
         vw
     }
 
+    /**
+     * Takes the params string and injects the initial regressor parameter.
+     * @param modelId The numeric model identifier.
+     * @return
+     */
     def updatedVwModelParams(modelId: Long): String = {
         val initialRegressorParam = s" -i ${localFile(modelId).getCanonicalPath} "
 
@@ -51,8 +96,12 @@ sealed trait VwJniModelSource extends Serializable {
         initialRegressorParam + params
     }
 
+    /**
+     * Finds the temp directory to be used.
+     * @return
+     */
     def tmpDir() = {
-        val t = File.createTempFile("abc123", "zyx987")
+        val t = File.createTempFile("DOESNT", "MATTER")
         t.deleteOnExit()
         val d = t.getParentFile.getCanonicalFile
         t.delete()
@@ -61,20 +110,35 @@ sealed trait VwJniModelSource extends Serializable {
 
 }
 
+/**
+ * A model source used when the VW binary model is encoded as a base64-encoded string.  The content will always
+ * be copied to a local temp file.
+ * @param b64EncodedBinaryVwModel A base64-encoded String representation of the binary VW model content.
+ * @param params VW model parameters
+ * @param timeMillis timestamp used to help name temp files.
+ */
 final case class Base64EncodedBinaryVwModelSource(
         b64EncodedBinaryVwModel: String,
         params: String = "",
         timeMillis: Long = System.currentTimeMillis()
 ) extends VwJniModelSource {
 
+    /**
+     * @return true
+     */
     def shouldDeleteLocalFile: Boolean = true
 
+    /**
+     * The local temp file.
+     * @param modelId The numeric model identifier.
+     * @return
+     */
     def localFile(modelId: Long): File = new File(tmpDir(), s"aloha.vw.$modelId.$timeMillis.model")
 
     /**
-     * Takes the model ID and base64-encoded binary VW model and creates a temp file with the decoded data
-     * and returns the file handle.
-     * @return File object for the newly created temp file
+     * Decodes the base64-encoded binary VW model and writes it to a temp file at ''dest''.
+     * @param dest where to write the binary VW model.
+     * @return
      */
     def copyContentToLocalIfNecessary(dest: File): Unit = {
         val decoded = Base64.decodeBase64(b64EncodedBinaryVwModel)
@@ -90,18 +154,43 @@ final case class Base64EncodedBinaryVwModelSource(
     }
 }
 
+/**
+ * A model source used when the ''location'' of the VW binary model provided.  If the model is available
+ * locally, it will neither be copied nor deleted.  Otherwise, it'll be copied and deleted when no longer
+ * needed.  The use case for this is copying a large VW model to each node on a cluster and using it over
+ * many batched runs without deleting.  This avoids the network overhead when copying from somewhere (like
+ * HDFS).
+ * @param fsInstance A file system instance pointing to a binary VW model file.  This could be backed by
+ *                   Apache VFS1, VFS2 or a File.  The reason to provide these different abstractions is
+ *                   that different file system abstractions have different plugins that allow different
+ *                   virtual file systems to be used.  For instance, the HDFS plugin used by eH is currently
+ *                   available for VFS1.  An S3 plugin might be on VFS2.  But VFS1 and VFS2 used in concert
+ *                   with each other may through exceptions.  Therefore, we allow the user to specify what
+ *                   to use so that automatic plugin support is available.
+ * @param params VW model parameters
+ * @param timeMillis timestamp used to help name temp files.
+ */
 final case class ExternallyDefinedVwModelSource(
         fsInstance: FsInstance,
         params: String = "",
         timeMillis: Long = System.currentTimeMillis()
 ) extends VwJniModelSource {
-    def shouldDeleteLocalFile: Boolean = !fsInstance.isLocal
+    def shouldDeleteLocalFile: Boolean = !fsInstance.existsLocally
 
+    /**
+     * Points to either a non-temp file that won't be deleted or a temp file that will be deleted.
+     * @param modelId The numeric model identifier.
+     * @return
+     */
     def localFile(modelId: Long): File =
         fsInstance.localFile getOrElse new File(tmpDir(), s"aloha.vw.$modelId.$timeMillis.model")
 
+    /**
+     * Only copies in the file system instance points to a file that is not local.
+     * @param dest local destination where the VW binary model will be copied.
+     */
     def copyContentToLocalIfNecessary(dest: File): Unit = {
-        if (!fsInstance.isLocal) {
+        if (!fsInstance.existsLocally) {
             val is = fsInstance.inputStream
             val os = new FileOutputStream(dest)
             try {

--- a/aloha-vw-jni/src/test/resources/com/eharmony/aloha/models/vw/jni/good.logistic.aloha.js
+++ b/aloha-vw-jni/src/test/resources/com/eharmony/aloha/models/vw/jni/good.logistic.aloha.js
@@ -8,7 +8,6 @@
     {"name": "personal_features", "features": [ "height_mm" ] }
   ],
   "vw": {
-    "via": "vfs2",
     "params": [
       "--quiet",
       "-t"

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
@@ -191,7 +191,6 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |    "personal_features": [ "height_mm" ]
                    |  },
                    |  "vw": {
-                   |    "via": "vfs2",
                    |    "params": "--quiet -t",
                    |    "model": """".stripMargin.trim + base64EncodedModelString + """"
                    |  }
@@ -229,7 +228,6 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |    "personal_features": [ "height_mm" ]
                    |  },
                    |  "vw": {
-                   |    "via": "vfs2",
                    |    "params": "--quiet -t",
                    |    "modelUrl": """".stripMargin.trim + url.getName.getPath + """"
                    |  }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/CliTest.scala
@@ -8,7 +8,7 @@ import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
 import org.junit.{BeforeClass, Test}
-import spray.json.{DeserializationException, pimpString}
+import spray.json.{JsObject, DeserializationException, pimpString}
 import org.apache.commons.vfs2
 
 object CliTest extends IoCaptureCompanion {
@@ -197,7 +197,10 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |}
                  """).stripMargin.parseJson
 
-            assertEquals(expected, outContent.parseJson)
+            val fields = outContent.parseJson.asJsObject.fields
+            val actual = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+
+            assertEquals(expected, actual)
         }
     }
 
@@ -229,12 +232,16 @@ class CliTest extends TestWithIoCapture(CliTest) {
                    |  },
                    |  "vw": {
                    |    "params": "--quiet -t",
-                   |    "modelUrl": """".stripMargin.trim + url.getName.getPath + """"
+                   |    "modelUrl": """".stripMargin.trim + url.getName.getPath + """",
+                   |    "via": "vfs2"
                    |  }
                    |}
                  """).stripMargin.parseJson
 
-            assertEquals(expected, outContent.parseJson)
+            val fields = outContent.parseJson.asJsObject.fields
+            val actual = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+
+            assertEquals(expected, actual)
         }
     }
 }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
@@ -9,7 +9,7 @@ import com.eharmony.matching.testhelp.io.IoCaptureCompanion
 import org.apache.commons.vfs2.VFS
 import org.junit.Assert._
 import org.junit.{BeforeClass, Test}
-import spray.json.pimpString
+import spray.json.{JsObject, pimpString}
 
 /**
  * These tests are now designed to pass if the VW model cannot be created in the BeforeClass method.
@@ -50,7 +50,10 @@ class VwJniModelJsonTest {
              |}
            """).stripMargin.parseJson
       val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"))
-      assertEquals(expected, actual)
+
+      val fields = actual.asJsObject.fields
+      val act = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+      assertEquals(expected, act)
   }
 
   @Test def withNotes() = {
@@ -75,7 +78,10 @@ class VwJniModelJsonTest {
              |}
            """).stripMargin.parseJson
       val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, Some(Seq("This is a note")))
-      assertEquals(expected, actual)
+
+      val fields = actual.asJsObject.fields
+      val act = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+      assertEquals(expected, act)
   }
 
   @Test def withSpline() = {
@@ -104,7 +110,10 @@ class VwJniModelJsonTest {
            """).stripMargin.parseJson
 
       val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, None, Some(cds))
-      assertEquals(expected, actual)
+
+      val fields = actual.asJsObject.fields
+      val act = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+      assertEquals(expected, act)
   }
 
   @Test def withNotesAndSpline() = {
@@ -134,6 +143,9 @@ class VwJniModelJsonTest {
              |}
            """).stripMargin.parseJson
       val actual = VwJniModel.json(vfsSpec, vfsModel, ModelId(0, "model name"), Some("--quiet -t"), false, None, Some(Seq("This is a note")), Some(cds))
-      assertEquals(expected, actual)
+
+      val fields = actual.asJsObject.fields
+      val act = JsObject(fields + ("vw" -> JsObject(fields("vw").asJsObject.fields - "creationDate")))
+      assertEquals(expected, act)
   }
 }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelJsonTest.scala
@@ -44,7 +44,6 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
-             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim +  base64EncodedModelString + """"
              |  }
@@ -70,7 +69,6 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
-             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }
@@ -99,7 +97,6 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
-             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }
@@ -131,7 +128,6 @@ class VwJniModelJsonTest {
              |    "personal_features": [ "height_mm" ]
              |  },
              |  "vw": {
-             |    "via": "vfs2",
              |    "params": "--quiet -t",
              |    "model": """".stripMargin.trim + base64EncodedModelString + """"
              |  }

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -144,8 +144,7 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None,
-                FsType.vfs2
+                None
             )
             fail("should throw IllegalArgumentException")
         }
@@ -170,8 +169,7 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None,
-                FsType.vfs2
+                None
             )
             fail("should throw IllegalArgumentException")
         }
@@ -196,8 +194,7 @@ class VwJniModelTest {
                 Nil,
                 (f: Double) => f,
                 None,
-                None,
-                FsType.vfs2
+                None
             )
             fail("should throw IllegalArgumentException")
         }
@@ -454,7 +451,6 @@ object VwJniModelTest extends Logging {
            |    "personal_features": [ "height_mm", "weight", "hair" ]
            |  },
            |  "vw": {
-           |    "via": "vfs1",
            |    "params": [
            |      "--quiet",
            |      "-t"

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -1,13 +1,13 @@
 package com.eharmony.aloha.models.vw.jni
 
 import java.io._
+import java.net.InetAddress.getLocalHost
 import java.{lang => jl}
 
 import com.eharmony.aloha.FileLocations
 import com.eharmony.aloha.factory.JavaJsonFormats._
 import com.eharmony.aloha.factory.ModelFactory
 import com.eharmony.aloha.id.ModelId
-import com.eharmony.aloha.io.fs.FsType
 import com.eharmony.aloha.models.TypeCoercion
 import com.eharmony.aloha.reflect.RefInfo
 import com.eharmony.aloha.score.conversions.ScoreConverter
@@ -39,32 +39,50 @@ import scala.util.Try
  * to load and these tests will consequently fail.
  */
 @RunWith(classOf[BlockJUnit4ClassRunner])
-class VwJniModelTest {
+class VwJniModelTest extends Logging {
     import VwJniModelTest._
 
+
     /**
-     * This test works locally but fails on jenkins.  Ignore for now.
+     * This test works locally but fails on jenkins.  So, have a list of blacklisted hosts
      */
-    @Ignore @Test def testSerialization(): Unit = {
-        val m = model[Double](typeTestJson)
+    @Test def testSerialization(): Unit = {
+        val hostName = getLocalHost.getHostName
+        if (BlacklistedHosts.findFirstMatchIn(hostName).isEmpty) {
+            val m = model[Double](typeTestJson)
 
-        val baos = new ByteArrayOutputStream()
-        val oos = new ObjectOutputStream(baos)
-        oos.writeObject(m)
-        oos.close()
+            val baos = new ByteArrayOutputStream()
+            val oos = new ObjectOutputStream(baos)
+            oos.writeObject(m)
+            oos.close()
 
-        val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
-        val m1 = ois.readObject().asInstanceOf[VwJniModel[CsvLine, Double]]
-        ois.close()
+            val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+            val m1 = ois.readObject().asInstanceOf[VwJniModel[CsvLine, Double]]
+            ois.close()
 
-        assertEquals(m.toString, m1.toString)
-        assertEquals(m(missingHeight), m1(missingHeight))
+            assertEquals(m.getClass.getCanonicalName, m1.getClass.getCanonicalName)
+
+
+            val ignoreIndices = Seq (
+                3, // featureFunctions
+                6  // finalizer
+            )
+
+            m.productIterator.zip(m1.productIterator).zipWithIndex.
+              filterNot(ignoreIndices contains _._2).foreach { case ((mProp, m1Prop), i) =>
+                assertEquals(s"For prop $i:", mProp, m1Prop)
+              }
+            assertEquals(m.toString, m1.toString)
+            assertEquals(m(missingHeight), m1(missingHeight))
+        }
+        else debug(s"$hostName matches BlacklistedHosts: ($BlacklistedHosts).  Ignoring test VwJniModelTest.testSerialization")
     }
+
 
     @Test def testFailureWhenVwIsCreatedWithLinkParamAndInitialRegressorHasSameLink(): Unit = {
         try {
-            val f = VwJniModel.allocateModel(1, logisticModelB64Encoded)
-            new VW(LogisticModelParams + s" -i ${f.getCanonicalPath}").close()
+            val src = Base64EncodedBinaryVwModelSource(logisticModelB64Encoded, LogisticModelParams)
+            src.vwModel(1).close()
             fail("VW should throw a java.lang.Exception with message: \"option '--link' cannot be specified more than once\"");
         }
         catch {
@@ -78,7 +96,9 @@ class VwJniModelTest {
     @Test def testAllocatedModelEqualsOriginalModel(): Unit = {
         val modelBytes = readFile(VwModelFile)
         val out = new String(Base64.encodeBase64(modelBytes))
-        val tmpFile = VwJniModel.allocateModel(1, out)
+        val src = Base64EncodedBinaryVwModelSource(out)
+        val tmpFile = src.localFile(1)
+        src.copyContentToLocalIfNecessary(tmpFile)
         val tmpBytes = readFile(tmpFile)
         println(out)
         assertArrayEquals(modelBytes, tmpBytes)
@@ -136,8 +156,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                Left(VwB64Model),
-                "--quiet",
+                Base64EncodedBinaryVwModelSource(VwB64Model, "--quiet"),
                 Vector("height_mm"),
                 Vector(h),
                 Nil,
@@ -161,8 +180,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                Left(VwB64Model),
-                "--quiet",
+                Base64EncodedBinaryVwModelSource(VwB64Model, "--quiet"),
                 Vector(),
                 Vector(h),
                 Nil,
@@ -186,8 +204,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                Left(VwB64Model),
-                "--quiet",
+                Base64EncodedBinaryVwModelSource(VwB64Model, "--quiet"),
                 Vector("height_mm"),
                 Vector(),
                 Nil,
@@ -221,19 +238,21 @@ class VwJniModelTest {
     @Test def testResUrlDoesntCopyToLocal(): Unit = {
         val resUrl = url("res:" + VwModelBaseName)
         val res = model[Float](extJson(resUrl.toString))
-        assertFalse("'res' URLs should copy VW model to temp directory.", res.finalVwParams.contains(TmpDir))
+        val params = res.vwJniModelSource.updatedVwModelParams(res.modelId.getId())
+        assertFalse("'res' URLs should copy VW model to temp directory.", params.contains(TmpDir))
     }
 
     @Test def testFileUrlDoesntCopyToLocal(): Unit = {
         val fileUrl = url(VwModelPath).toString
         val file = model[Float](extJson(fileUrl))
-        assertFalse("'file' URLs should not copy VW model to temp directory.", file.finalVwParams.contains(TmpDir))
+        val params = file.vwJniModelSource.updatedVwModelParams(file.modelId.getId())
+        assertFalse("'file' URLs should not copy VW model to temp directory.", params.contains(TmpDir))
     }
 
     @Test def testNakedUrlDoesntCopyToLocal(): Unit = {
         val naked = model[Float](extJson(VwModelPath))
-        assertFalse("URLs with no protocol should not copy VW model to temp directory.", naked.finalVwParams.contains(TmpDir))
-
+        val params = naked.vwJniModelSource.updatedVwModelParams(naked.modelId.getId())
+        assertFalse("URLs with no protocol should not copy VW model to temp directory.", params.contains(TmpDir))
     }
 
     @Test def testTmpUrlCopiesToLocal(): Unit = {
@@ -242,11 +261,12 @@ class VwJniModelTest {
         vfs2.FileUtil.copyContent(url(VwModelPath), tmpUrl)
         val tmp = model[Float](extJson(tmpUrl.toString))
         val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
-        tmp.finalVwParams match {
+        val params = tmp.vwJniModelSource.updatedVwModelParams(tmp.modelId.getId())
+        params match {
             case file(tmpFile) =>
                 assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
-                assertTrue("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(TmpDir))
-                assertFalse("'tmp' URLs should copy VW model to temp directory.", tmp.finalVwParams.contains(tmpUrlPath))
+                assertTrue("'tmp' URLs should copy VW model to temp directory.", params.contains(TmpDir))
+                assertFalse("'tmp' URLs should copy VW model to temp directory.", params.contains(tmpUrlPath))
             case _ => fail("Should have a temp file location")
         }
     }
@@ -258,11 +278,13 @@ class VwJniModelTest {
         val ram = model[Float](extJson(ramUrl.toString))
 
         val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
-        ram.finalVwParams match {
+        val params = ram.vwJniModelSource.updatedVwModelParams(ram.modelId.getId())
+
+        params match {
             case file(tmpFile) =>
                 assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
-                assertTrue("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(TmpDir))
-                assertFalse("'ram' URLs should copy VW model to temp directory.", ram.finalVwParams.contains(ramUrlPath))
+                assertTrue("'ram' URLs should copy VW model to temp directory.", params.contains(TmpDir))
+                assertFalse("'ram' URLs should copy VW model to temp directory.", params.contains(ramUrlPath))
             case _ => fail("Should have a temp file location")
         }
     }
@@ -281,10 +303,12 @@ class VwJniModelTest {
         val gz = model[Float](extJson(gzUrl.toString))
 
         val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
-        gz.finalVwParams match {
+        val params = gz.vwJniModelSource.updatedVwModelParams(gz.modelId.getId())
+
+        params match {
             case file(tmpFile) =>
                 assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
-                assertTrue("'gz' URLs should copy VW model to temp directory.", gz.finalVwParams.contains(TmpDir))
+                assertTrue("'gz' URLs should copy VW model to temp directory.", params.contains(TmpDir))
             case _ => fail("Should have a temp file location")
         }
     }
@@ -303,10 +327,12 @@ class VwJniModelTest {
         val bz2 = model[Float](extJson(bz2Url.toString))
 
         val file = """^.*\s+-i\s*([^\s]*\.model).*$""".r
-        bz2.finalVwParams match {
+        val params = bz2.vwJniModelSource.updatedVwModelParams(bz2.modelId.getId())
+
+        params match {
             case file(tmpFile) =>
                 assertFalse(s"Temp file ($tmpFile) should already be deleted.", new File(tmpFile).exists())
-                assertTrue("'zip' URLs should copy VW model to temp directory.", bz2.finalVwParams.contains(TmpDir))
+                assertTrue("'zip' URLs should copy VW model to temp directory.", params.contains(TmpDir))
             case _ => fail("Should have a temp file location")
         }
     }
@@ -377,6 +403,8 @@ class VwJniModelTest {
 }
 
 object VwJniModelTest extends Logging {
+    private[jni] val BlacklistedHosts = """^.*\.prod\.dc1\.eharmony\.com$""".r
+
     private[jni] val VwModelBaseName = "VwJniModelTest-vw.model"
     private[jni] val VwModelFile = new File(FileLocations.testClassesDirectory, VwModelBaseName)
     private[jni] val VwModelPath = VwModelFile.getCanonicalPath

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -45,8 +45,7 @@ class VwJniModelTest {
     /**
      * This test works locally but fails on jenkins.  Ignore for now.
      */
-    @Ignore
-    @Test def testSerialization(): Unit = {
+    @Ignore @Test def testSerialization(): Unit = {
         val m = model[Double](typeTestJson)
 
         val baos = new ByteArrayOutputStream()
@@ -455,6 +454,7 @@ object VwJniModelTest extends Logging {
            |    "personal_features": [ "height_mm", "weight", "hair" ]
            |  },
            |  "vw": {
+           |    "via": "vfs1",
            |    "params": [
            |      "--quiet",
            |      "-t"

--- a/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
+++ b/aloha-vw-jni/src/test/scala/com/eharmony/aloha/models/vw/jni/VwJniModelTest.scala
@@ -136,7 +136,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                VwB64Model,
+                Left(VwB64Model),
                 "--quiet",
                 Vector("height_mm"),
                 Vector(h),
@@ -161,7 +161,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                VwB64Model,
+                Left(VwB64Model),
                 "--quiet",
                 Vector(),
                 Vector(h),
@@ -186,7 +186,7 @@ class VwJniModelTest {
         try {
             VwJniModel(
                 ModelId.empty,
-                VwB64Model,
+                Left(VwB64Model),
                 "--quiet",
                 Vector("height_mm"),
                 Vector(),

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.5</version>
+                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
I have tested this on Spark in a distributed environment.  This does indeed fix the bug, however:
1.  I haven't written any tests and frankly I don't know how as I can't emulate cross machine serialization in a one machine environment.
2.  @deaktator please review this code and let me know what you think of it.

Also because of the removal of the need for VFS anywhere in the pipeline when using an embedded model I can (and did) mostly undo issue 32.  The via flag is no longer required when using an embedded model (as it probably should not have been all along).

I've gone one step further and removed the apply method from the VwJniModel companion object.  This is no longer necessary as the class constructor can now handle the Either appropriately.
