### PR TITLE
83 exploration library

### DIFF
--- a/aloha-cli/src/test/scala/com/eharmony/aloha/cli/ModelTypesTest.scala
+++ b/aloha-cli/src/test/scala/com/eharmony/aloha/cli/ModelTypesTest.scala
@@ -15,10 +15,12 @@ import org.junit.runners.BlockJUnit4ClassRunner
 class ModelTypesTest {
     @Test def testKnownModels(): Unit = {
         val expected = Seq(
+            "BootstrapExploration",
             "CategoricalDistribution",
             "Constant",
             "DecisionTree",
             "DoubleToLong",
+            "EpsilonGreedyExploration",
             "Error",
             "ErrorSwallowingModel",
             "H2o",

--- a/aloha-core/pom.xml
+++ b/aloha-core/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.github.multiworldtesting</groupId>
 			<artifactId>explore-java</artifactId>
-			<version>1.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 
 		<!-- ============================================================================= -->

--- a/aloha-core/pom.xml
+++ b/aloha-core/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>com.eharmony</groupId>
 			<artifactId>aloha-proto</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -127,6 +127,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.multiworldtesting</groupId>
+			<artifactId>explore-java</artifactId>
+			<version>1.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- ============================================================================= -->

--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelParser.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelParser.scala
@@ -47,6 +47,12 @@ trait ModelParser extends JsValuePimpz {
     final def getParser[A: RefInfo, B: RefInfo: JsonReader: ScoreConverter](factory: ModelFactory, semantics: Option[Semantics[A]]) = new Parser[JsValue, Model[A, B]] {
         def parse(json: JsValue): Model[A, B] = json.convertTo(modelJsonReader[A, B](factory, semantics))
     }
+
+    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
+    protected[this] def lift[A](reader: JsonReader[A]) = new JsonFormat[A] {
+        def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
+        def read(value: JsValue) = reader.read(value)
+    }
 }
 
 trait BasicModelParser extends ModelParser {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelParser.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelParser.scala
@@ -47,12 +47,6 @@ trait ModelParser extends JsValuePimpz {
     final def getParser[A: RefInfo, B: RefInfo: JsonReader: ScoreConverter](factory: ModelFactory, semantics: Option[Semantics[A]]) = new Parser[JsValue, Model[A, B]] {
         def parse(json: JsValue): Model[A, B] = json.convertTo(modelJsonReader[A, B](factory, semantics))
     }
-
-    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
-    protected[this] def lift[A](reader: JsonReader[A]) = new JsonFormat[A] {
-        def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
-        def read(value: JsValue) = reader.read(value)
-    }
 }
 
 trait BasicModelParser extends ModelParser {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/formats.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/formats.scala
@@ -51,6 +51,12 @@ trait JavaJsonFormats {
 object ScalaJsonFormats extends ScalaJsonFormats
 
 trait ScalaJsonFormats {
+    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
+    implicit def lift[A](implicit reader: JsonReader[A]): JsonFormat[A] = new JsonFormat[A] {
+        def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
+        def read(value: JsValue): A = reader.read(value)
+    }
+
     implicit def listMapFormat[K :JsonFormat, V :JsonFormat] = new RootJsonFormat[ListMap[K, V]] {
         def write(m: ListMap[K, V]) = JsObject {
             m.map { field =>

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/SegmentationModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/SegmentationModel.scala
@@ -67,7 +67,7 @@ object SegmentationModel extends ParserProviderCompanion {
             }
         }
 
-        protected[this] def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "subModel", "subModelOutputType", "thresholds", "labels")
+        protected[this] implicit def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "subModel", "subModelOutputType", "thresholds", "labels")
 
         /**
          * @param factory ModelFactory[Model[_, _] ]
@@ -77,9 +77,11 @@ object SegmentationModel extends ParserProviderCompanion {
          */
         def modelJsonReader[A, B](factory: ModelFactory, semantics: Option[Semantics[A]])(implicit jr: JsonReader[B], sc: ScoreConverter[B]) =  new JsonReader[SegmentationModel[A, _, B]] {
             def read(json: JsValue): SegmentationModel[A, _, B] = {
+                import com.eharmony.aloha.factory.ScalaJsonFormats.lift
+
                 // TODO: Make this way better and way more generalized so that it can be used in the ensemble code.
                 val mId = getModelId(json).get
-                val ast = json.convertTo(astJsonFormat(lift(jr), sc))
+                val ast = json.convertTo[Ast[B]]
 
                 import ScoreConverter.Implicits._
 

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/SegmentationModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/SegmentationModel.scala
@@ -69,12 +69,6 @@ object SegmentationModel extends ParserProviderCompanion {
 
         protected[this] def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "subModel", "subModelOutputType", "thresholds", "labels")
 
-        // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
-        protected[this] def lift[A](reader :JsonReader[A]) = new JsonFormat[A] {
-            def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
-            def read(value: JsValue) = reader.read(value)
-        }
-
         /**
          * @param factory ModelFactory[Model[_, _] ]
          * @tparam A model input type

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -1,0 +1,109 @@
+package com.eharmony.aloha.models.exploration
+
+import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderCompanion}
+import com.eharmony.aloha.id.ModelIdentity
+import com.eharmony.aloha.models.{Model, BaseModel}
+import com.eharmony.aloha.score.Scores.Score
+import com.eharmony.aloha.score.basic.{ModelFailure, ModelOutput}
+import com.eharmony.aloha.score.conversions.ScoreConverter
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
+import com.eharmony.aloha.semantics.Semantics
+import com.mwt.explorers.BootstrapExplorer
+import com.mwt.policies.Policy
+
+import scala.collection.JavaConversions.seqAsJavaList
+import scala.collection.{immutable => sci}
+
+case class NumberedPolicy(index: Int) extends Policy[sci.IndexedSeq[Int]] {
+  override def chooseAction(actions: sci.IndexedSeq[Int]): Int = actions(index)
+}
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+case class BootstrapModel[A, B](
+  modelId: ModelIdentity,
+  models: sci.IndexedSeq[Model[A, Int]],
+  salt: Long,
+  classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] {
+
+  val explorer = new BootstrapExplorer[sci.IndexedSeq[Int]](models.indices.map(i => NumberedPolicy(i): Policy[sci.IndexedSeq[Int]]), classLabels.size)
+
+  /** Produce a score.
+    * @param a an input to the model representing covariate data.
+    * @param audit Whether the second field of the result Tuple2 should be Some (true) or None (false)
+    * @return a Tuple2 whose first field represents a simple version of the score, the second field (that should be
+    *         a Some instance if audit is true) is a more involved reporting of the score including errors and all
+    *         sub-model scores.
+    */
+  override private[aloha] def getScore(a: A)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
+    val mos = models.map(_.getScore(a))
+
+    // TODO This can be done better using ApplicativeFunctors and sequence from scalaz.
+    val scores = for {
+      m <- mos
+      result <- m._1.right.toOption
+    } yield result
+
+    // Since we know we have at least 1 failure calling get on the option here is guaranteed to succeed.
+    // I know this is bad, the above to do should fix it.
+    if (scores.size != mos.size)
+      mos.collectFirst{ case (Left(error), os) => failure(error._1, error._2, os) }.get
+    else {
+      val decision = explorer.chooseAction(salt, scores)
+
+      val s = success(
+        score = classLabels(decision.getAction - 1),
+        subScores = mos.flatMap(_._2),
+        probability = Option(decision.getProbability)
+      )
+      s
+    }
+  }
+
+  override def close() = models.foreach(_.close())
+}
+
+object BootstrapModel extends ParserProviderCompanion {
+
+  object Parser extends ModelParser {
+    val modelType = "BootstrapExploration"
+
+    import spray.json._, DefaultJsonProtocol._
+
+    protected[this] case class Ast[B: JsonReader: ScoreConverter](policies: sci.IndexedSeq[JsValue], salt: Long, classLabels: sci.IndexedSeq[B]) {
+      def createModel[A, B](factory: ModelFactory, semantics: Semantics[A], modelId: ModelIdentity) = {
+        val models = policies.map(factory.getModel(_, Option(semantics))(semantics.refInfoA, IntScoreConverter.ri, IntJsonFormat, IntScoreConverter).get)
+        BootstrapModel(modelId, models, salt, classLabels)
+      }
+    }
+
+    protected[this] def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "policies", "salt", "classLabels")
+
+    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
+    protected[this] def lift[A](reader: JsonReader[A]) = new JsonFormat[A] {
+      def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
+      def read(value: JsValue) = reader.read(value)
+    }
+
+    /**
+      * @param factory ModelFactory[Model[_, _] ]
+      * @tparam A model input type
+      * @tparam B model input type
+      * @return
+      */
+    def modelJsonReader[A, B](factory: ModelFactory, semantics: Option[Semantics[A]])
+      (implicit jr: JsonReader[B], sc: ScoreConverter[B]) = new JsonReader[BootstrapModel[A, B]] {
+      def read(json: JsValue): BootstrapModel[A, B] = {
+        val mId = getModelId(json).get
+        val ast = json.convertTo(astJsonFormat(lift(jr), sc))
+
+        val model = ast.createModel[A, B](factory, semantics.get, mId)
+
+        model
+      }
+    }
+  }
+
+  override def parser: ModelParser = Parser
+}

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -27,7 +27,10 @@ case class BootstrapModel[A, B](
   salt: Long,
   classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] {
 
-  val explorer = new BootstrapExplorer[sci.IndexedSeq[Int]](models.indices.map(i => NumberedPolicy(i): Policy[sci.IndexedSeq[Int]]), classLabels.size)
+  @transient lazy val explorer = new BootstrapExplorer[sci.IndexedSeq[Int]](
+    models.indices.map(i => NumberedPolicy(i): Policy[sci.IndexedSeq[Int]]),
+    classLabels.size
+  )
 
   /** Produce a score.
     * @param a an input to the model representing covariate data.

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -2,14 +2,13 @@ package com.eharmony.aloha.models.exploration
 
 import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderCompanion}
 import com.eharmony.aloha.id.ModelIdentity
-import com.eharmony.aloha.models.{Model, BaseModel}
+import com.eharmony.aloha.models.{BaseModel, Model}
 import com.eharmony.aloha.score.Scores.Score
-import com.eharmony.aloha.score.basic.{ModelSuccess, ModelFailure, ModelOutput}
+import com.eharmony.aloha.score.basic.ModelOutput
 import com.eharmony.aloha.score.conversions.ScoreConverter
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
 import com.eharmony.aloha.semantics.Semantics
 import com.eharmony.aloha.semantics.func.GenAggFunc
-import com.eharmony.aloha.util.EitherHelpers
 import com.mwt.explorers.BootstrapExplorer
 import com.mwt.policies.Policy
 
@@ -45,7 +44,7 @@ case class BootstrapModel[A, B](
   modelId: ModelIdentity,
   models: sci.IndexedSeq[Model[A, Int]],
   salt: GenAggFunc[A, Long],
-  classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] with EitherHelpers {
+  classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] {
 
   @transient private[this] lazy val explorer = new BootstrapExplorer[sci.IndexedSeq[Int]](
     models.indices.map(i => NumberedPolicy(i): Policy[sci.IndexedSeq[Int]]),
@@ -101,7 +100,8 @@ object BootstrapModel extends ParserProviderCompanion {
   object Parser extends ModelParser {
     val modelType = "BootstrapExploration"
 
-    import spray.json._, DefaultJsonProtocol._
+    import spray.json._
+    import DefaultJsonProtocol._
 
     protected[this] case class Ast[B: JsonReader: ScoreConverter](policies: sci.IndexedSeq[JsValue], salt: String, classLabels: sci.IndexedSeq[B]) {
       def createModel[A, B](factory: ModelFactory, semantics: Semantics[A], modelId: ModelIdentity) = {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -28,7 +28,8 @@ private[this] case class NumberedPolicy(index: Int) extends Policy[sci.IndexedSe
 
 /**
   * A model for performing bootstrap style exploration.  This makes use of a number of policies.  The algorithm chooses
-  * one policy and then uses the other to calculate the appropriate probability of choosing that action.
+  * one policy and then uses the other to calculate the appropriate probability of choosing that action.  Note that the
+  * models MUST return a value between 1 and the number of actions, and if not an exception will be thrown.
   * @param modelId a model identifier
   * @param models a set of models that generate Int's.  These models MUST be deterministic for the probability to be correct.
   *               Each model must return a value in the range 1 to `classLabels.size` (inclusive).

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -31,6 +31,7 @@ private[this] case class NumberedPolicy(index: Int) extends Policy[sci.IndexedSe
   * one policy and then uses the other to calculate the appropriate probability of choosing that action.
   * @param modelId a model identifier
   * @param models a set of models that generate Int's.  These models MUST be deterministic for the probability to be correct.
+  *               Each model must return a value in the range 1 to `classLabels.size` (inclusive).
   * @param salt a function that generates a salt for the randomization layer.  This salt allows the random choice of which policy
   *             to follow to be repeatable.
   * @param classLabels a list of class labels to output for the final type.  Also note that the size of this controls the

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -73,7 +73,7 @@ case class BootstrapModel[A, B](
     a: A,
     models: sci.IndexedSeq[Model[A, Int]],
     subScores: Seq[Score] = Seq.empty,
-    successes: sci.IndexedSeq[Int] = sci.IndexedSeq.empty): (ModelOutput[B], Option[Score]) = {
+    successes: sci.IndexedSeq[Int] = sci.IndexedSeq.empty)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
     if (models.isEmpty) {
       val decision = explorer.chooseAction(salt(a), successes)
       success(

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -2,7 +2,7 @@ package com.eharmony.aloha.models.exploration
 
 import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderCompanion}
 import com.eharmony.aloha.id.ModelIdentity
-import com.eharmony.aloha.models.{Model, BaseModel}
+import com.eharmony.aloha.models.{BaseModel, Model}
 import com.eharmony.aloha.score.Scores.Score
 import com.eharmony.aloha.score.basic.ModelOutput
 import com.eharmony.aloha.score.conversions.ScoreConverter
@@ -77,7 +77,8 @@ object EpsilonGreedyModel extends ParserProviderCompanion {
   object Parser extends ModelParser {
     val modelType = "EpsilonGreedyExploration"
 
-    import spray.json._, DefaultJsonProtocol._
+    import spray.json._
+    import DefaultJsonProtocol._
 
     protected[this] case class Ast[B: JsonReader: ScoreConverter](defaultPolicy: JsValue, epsilon: Float, salt: String, classLabels: sci.IndexedSeq[B]) {
       def createModel[A, B](factory: ModelFactory, semantics: Semantics[A], modelId: ModelIdentity) = {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -25,7 +25,8 @@ private[this] case object ModelPolicy extends Policy[Int] {
 
 /**
   * A model which does epsilon greedy style exploration.  This will choose a random action with probability epsilon
-  * or an action from the defaultPolicy with probability 1 - epsilon.
+  * or an action from the defaultPolicy with probability 1 - epsilon.  Note that the
+  * default policy MUST return a value between 1 and the number of actions, and if not an exception will be thrown.
   * @param modelId a model identifier
   * @param defaultPolicy the model to use for exploitation.  This MUST be deterministic for the probability to be correct.
   *                      The model must return a value in the range 1 to `classLabels.size` (inclusive).

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -1,0 +1,99 @@
+package com.eharmony.aloha.models.exploration
+
+import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderCompanion}
+import com.eharmony.aloha.id.ModelIdentity
+import com.eharmony.aloha.models.{Model, BaseModel}
+import com.eharmony.aloha.score.Scores.Score
+import com.eharmony.aloha.score.basic.ModelOutput
+import com.eharmony.aloha.score.conversions.ScoreConverter
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
+import com.eharmony.aloha.semantics.Semantics
+import com.mwt.explorers.EpsilonGreedyExplorer
+import com.mwt.policies.Policy
+
+import scala.collection.{immutable => sci}
+
+case object ModelPolicy extends Policy[Int] {
+  override def chooseAction(action: Int): Int = action
+}
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+case class EpsilonGreedyModel[A, B](
+  modelId: ModelIdentity,
+  defaultPolicy: Model[A, Int],
+  epsilon: Float,
+  salt: Long,
+  classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] {
+
+  val explorer = new EpsilonGreedyExplorer(ModelPolicy, epsilon, classLabels.size)
+
+  /** Produce a score.
+    * @param a an input to the model representing covariate data.
+    * @param audit Whether the second field of the result Tuple2 should be Some (true) or None (false)
+    * @return a Tuple2 whose first field represents a simple version of the score, the second field (that should be
+    *         a Some instance if audit is true) is a more involved reporting of the score including errors and all
+    *         sub-model scores.
+    */
+  override private[aloha] def getScore(a: A)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
+    val (mo, os) = defaultPolicy.getScore(a)
+    val decision = mo.right.map(explorer.chooseAction(salt, _))
+
+    val s = decision.fold(
+      {case (e, m) => failure(e, m, os)},
+      sc => success(
+        score = classLabels(sc.getAction - 1),
+        subScores = os,
+        probability = Option(sc.getProbability)
+      )
+    )
+    s
+  }
+
+  override def close() = defaultPolicy.close()
+}
+
+object EpsilonGreedyModel extends ParserProviderCompanion {
+
+  object Parser extends ModelParser {
+    val modelType = "EpsilonGreedyExploration"
+
+    import spray.json._, DefaultJsonProtocol._
+
+    protected[this] case class Ast[B: JsonReader: ScoreConverter](defaultPolicy: JsValue, epsilon: Float, salt: Long, classLabels: sci.IndexedSeq[B]) {
+      def createModel[A, B](factory: ModelFactory, semantics: Semantics[A], modelId: ModelIdentity) = {
+        val m = factory.getModel(defaultPolicy, Option(semantics))(semantics.refInfoA, IntScoreConverter.ri, IntJsonFormat, IntScoreConverter).get
+        EpsilonGreedyModel(modelId, m, epsilon, salt, classLabels)
+      }
+    }
+
+    protected[this] def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "defaultPolicy", "epsilon", "salt", "classLabels")
+
+    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
+    protected[this] def lift[A](reader: JsonReader[A]) = new JsonFormat[A] {
+      def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
+      def read(value: JsValue) = reader.read(value)
+    }
+
+    /**
+      * @param factory ModelFactory[Model[_, _] ]
+      * @tparam A model input type
+      * @tparam B model input type
+      * @return
+      */
+    def modelJsonReader[A, B](factory: ModelFactory, semantics: Option[Semantics[A]])
+      (implicit jr: JsonReader[B], sc: ScoreConverter[B]) = new JsonReader[EpsilonGreedyModel[A, B]] {
+      def read(json: JsValue): EpsilonGreedyModel[A, B] = {
+        val mId = getModelId(json).get
+        val ast = json.convertTo(astJsonFormat(lift(jr), sc))
+
+        val model = ast.createModel[A, B](factory, semantics.get, mId)
+
+        model
+      }
+    }
+  }
+
+  override def parser: ModelParser = Parser
+}

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -29,7 +29,9 @@ private[this] case object ModelPolicy extends Policy[Int] {
   * @param modelId a model identifier
   * @param defaultPolicy the model to use for exploitation.  This MUST be deterministic for the probability to be correct.
   *                      The model must return a value in the range 1 to `classLabels.size` (inclusive).
-  * @param epsilon the exploration/exploitation tradeoff parameter
+  * @param epsilon the exploration/exploitation tradeoff parameter.  epsilon must be in the interval [0, 1].
+  *                0 indicates never select an action randomly.
+  *                1 indicates always select an action randomly.
   * @param salt a function that generates a salt for the randomization layer.  This salt allows the random choice of which policy
   *             to follow to be repeatable.
   * @param classLabels a list of class labels to output for the final type.  Also note that the size of this controls the

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -70,12 +70,6 @@ object EpsilonGreedyModel extends ParserProviderCompanion {
 
     protected[this] def astJsonFormat[B: JsonFormat: ScoreConverter] = jsonFormat(Ast.apply[B], "defaultPolicy", "epsilon", "salt", "classLabels")
 
-    // This is a very slightly modified copy of the lift from Additional formats that removes the type bound.
-    protected[this] def lift[A](reader: JsonReader[A]) = new JsonFormat[A] {
-      def write(a: A): JsValue = throw new UnsupportedOperationException("No JsonWriter[" + a.getClass + "] available")
-      def read(value: JsValue) = reader.read(value)
-    }
-
     /**
       * @param factory ModelFactory[Model[_, _] ]
       * @tparam A model input type

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -28,6 +28,7 @@ private[this] case object ModelPolicy extends Policy[Int] {
   * or an action from the defaultPolicy with probability 1 - epsilon.
   * @param modelId a model identifier
   * @param defaultPolicy the model to use for exploitation.  This MUST be deterministic for the probability to be correct.
+  *                      The model must return a value in the range 1 to `classLabels.size` (inclusive).
   * @param epsilon the exploration/exploitation tradeoff parameter
   * @param salt a function that generates a salt for the randomization layer.  This salt allows the random choice of which policy
   *             to follow to be repeatable.

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -27,7 +27,7 @@ case class EpsilonGreedyModel[A, B](
   salt: Long,
   classLabels: sci.IndexedSeq[B])(implicit scB: ScoreConverter[B]) extends BaseModel[A, B] {
 
-  val explorer = new EpsilonGreedyExplorer(ModelPolicy, epsilon, classLabels.size)
+  @transient lazy val explorer = new EpsilonGreedyExplorer(ModelPolicy, epsilon, classLabels.size)
 
   /** Produce a score.
     * @param a an input to the model representing covariate data.

--- a/aloha-core/src/test/java/com/eharmony/aloha/factory/JavaDefaultModelFactoryTest.java
+++ b/aloha-core/src/test/java/com/eharmony/aloha/factory/JavaDefaultModelFactoryTest.java
@@ -9,6 +9,8 @@ import java.util.Collection;
 import java.util.Arrays;
 
 import com.eharmony.aloha.models.conversion.DoubleToLongModel;
+import com.eharmony.aloha.models.exploration.BootstrapModel;
+import com.eharmony.aloha.models.exploration.EpsilonGreedyModel;
 import scala.collection.JavaConversions;
 import scala.collection.immutable.List;
 import scala.util.Try;
@@ -78,7 +80,9 @@ public class JavaDefaultModelFactoryTest {
                 RegressionModel.parser().modelType(),
                 SegmentationModel.parser().modelType(),
                 DoubleToLongModel.parser().modelType(),
-                ErrorSwallowingModel.parser().modelType()
+                ErrorSwallowingModel.parser().modelType(),
+                EpsilonGreedyModel.parser().modelType(),
+                BootstrapModel.parser().modelType()
         };
 
         Arrays.sort(names);

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/AnySemanticsWithoutFunctionCreation.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/AnySemanticsWithoutFunctionCreation.scala
@@ -1,0 +1,23 @@
+package com.eharmony.aloha.models
+
+import com.eharmony.aloha.reflect._
+import com.eharmony.aloha.semantics.Semantics
+import com.eharmony.aloha.semantics.func.GenFunc0
+
+import scala.util.Try
+
+/**
+  * Created by jmorra on 2/29/16.
+  */
+object AnySemanticsWithoutFunctionCreation extends Semantics[Any] {
+  def refInfoA = RefInfo[Any]
+  def accessorFunctionNames = Nil
+  def close() {}
+  def createFunction[B: RefInfo](codeSpec: String, default: Option[B]) = {
+    val right = Try {
+      val long = codeSpec.toLong
+      Right(GenFunc0(codeSpec, (a: Any) => long.asInstanceOf[B]))
+    }
+    right.getOrElse(Left(Seq("createFunction not supported.")))
+  }
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/SegmentationModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/SegmentationModelTest.scala
@@ -1,19 +1,16 @@
 package com.eharmony.aloha.models
 
 import com.eharmony.aloha.ModelSerializationTestHelper
-import com.eharmony.aloha.id.{ModelId, ModelIdentity}
-import com.eharmony.aloha.models.conversion.DoubleToJavaLongModel
-import com.eharmony.aloha.score.conversions.ScoreConverter
+import com.eharmony.aloha.id.ModelId
 import org.junit.runners.BlockJUnit4ClassRunner
 import org.junit.runner.RunWith
 import org.junit.Test
 import org.junit.Assert._
 
-import spray.json.DefaultJsonProtocol.{StringJsonFormat, IntJsonFormat}
+import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.{DeserializationException, pimpString}
 
 import com.eharmony.aloha.factory.ModelFactory
-import com.eharmony.aloha.semantics.Semantics
 import com.eharmony.aloha.reflect.{RefInfoOps, RefInfo}
 import com.eharmony.aloha.score.conversions.rich.RichScore
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.{IntScoreConverter, StringScoreConverter}
@@ -34,13 +31,6 @@ class SegmentationModelTest extends ModelSerializationTestHelper {
         val sub = new CloserTesterModel[Int]()
         SegmentationModel(ModelId.empty, sub, Vector(1, 2), Vector(1, 2, 3)).close()
         assertTrue(sub.isClosed)
-    }
-
-    private[this] object AnySemanticsWithoutFunctionCreation extends Semantics[Any] {
-        def refInfoA = RefInfo[Any]
-        def accessorFunctionNames = Nil
-        def close() {}
-        def createFunction[B: RefInfo](codeSpec: String, default: Option[B]) = Left(Seq("createFunction not supported."))
     }
 
     @Test def testHappyPath_Byte()   { simpleTest(_.toByte) }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelParserTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelParserTest.scala
@@ -1,0 +1,8 @@
+package com.eharmony.aloha.models.exploration
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+class BootstrapModelParserTest {
+
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelParserTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelParserTest.scala
@@ -1,8 +1,108 @@
 package com.eharmony.aloha.models.exploration
 
+import com.eharmony.aloha.factory.ModelFactory
+import com.eharmony.aloha.models.{AnySemanticsWithoutFunctionCreation, ConstantModel}
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.StringScoreConverter
+import org.junit.Assert._
+import org.junit.Test
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
 /**
   * Created by jmorra on 2/26/16.
   */
 class BootstrapModelParserTest {
+  private[this] val reader = BootstrapModel.Parser.modelJsonReader[Any, String](ModelFactory(ConstantModel.parser), Option(AnySemanticsWithoutFunctionCreation))
 
+  @Test def goodModel() {
+    val js =
+      """
+        |{
+        | "modelType": "BootstrapExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "salt": "0",
+        | "policies": [
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 1, "name": ""},
+        |     "value": 1
+        |   },
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 2, "name": ""},
+        |     "value": 2
+        |   }
+        | ],
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    val m = reader.read(js)
+    val s = m(null)
+    assertEquals("b", s.get)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noClassLabels() {
+    val js =
+      """
+        |{
+        | "modelType": "BootstrapExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "salt": 0,
+        | "policies": [
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 1, "name": ""},
+        |     "value": 1
+        |   },
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 2, "name": ""},
+        |     "value": 2
+        |   }
+        | ]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noSalt() {
+    val js =
+      """
+        |{
+        | "modelType": "BootstrapExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "policies": [
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 1, "name": ""},
+        |     "value": 1
+        |   },
+        |   {
+        |     "modelType": "Constant",
+        |     "modelId": {"id": 2, "name": ""},
+        |     "value": 2
+        |   }
+        | ],
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noPolicies() {
+    val js =
+      """
+        |{
+        | "modelType": "BootstrapExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "salt": 0,
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
 }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
@@ -47,21 +47,21 @@ class BootstrapModelTest extends ModelSerializationTestHelper {
 
   @Test def saltZero() {
     val m = makeModel(Seq(1, 2, 3), 0)
-    val s = m.getScore()
+    val s = m.getScore(null)
     assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
     assertEquals(s._1.right.get, "a")
   }
 
   @Test def saltOne() {
     val m = makeModel(Seq(1, 2, 3), 1)
-    val s = m.getScore()
+    val s = m.getScore(null)
     assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
     assertEquals(s._1.right.get, "b")
   }
 
   @Test def saltTwo() {
     val m = makeModel(Seq(1, 2, 3), 2)
-    val s = m.getScore()
+    val s = m.getScore(null)
     assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
     assertEquals(s._1.right.get, "c")
   }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
@@ -1,11 +1,15 @@
 package com.eharmony.aloha.models.exploration
 
 import com.eharmony.aloha.ModelSerializationTestHelper
+import com.eharmony.aloha.factory.ModelFactory
 import com.eharmony.aloha.id.ModelId
-import com.eharmony.aloha.models.ConstantModel
+import com.eharmony.aloha.models.{AnySemanticsWithoutFunctionCreation, CloserTesterModel, ConstantModel}
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits._
+import com.eharmony.aloha.semantics.func.GenFunc0
 import org.junit.Assert._
 import org.junit.Test
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 import scala.collection.{immutable => sci}
 
@@ -13,20 +17,77 @@ import scala.collection.{immutable => sci}
   * Created by jmorra on 2/26/16.
   */
 class BootstrapModelTest extends ModelSerializationTestHelper {
-  val polices = sci.IndexedSeq(
-    ConstantModel(Right(1), ModelId(1, "abc")),
-    ConstantModel(Right(2), ModelId(2, "abc")),
-    ConstantModel(Right(1), ModelId(3, "abc"))
-  )
+  private[this] val Reader = BootstrapModel.Parser.modelJsonReader[Any, String](ModelFactory(ConstantModel.parser), Option(AnySemanticsWithoutFunctionCreation))
+  private[this] val delta = 0.00001f
+  implicit val audit = true
 
-  @Test def testSerialization(): Unit = {
+  @Test def testSerialization() {
+    val polices = sci.IndexedSeq(
+      ConstantModel(Right(1), ModelId(1, "abc")),
+      ConstantModel(Right(2), ModelId(2, "abc")),
+      ConstantModel(Right(1), ModelId(3, "abc"))
+    )
 
-    val m = BootstrapModel(ModelId(4, "def"), polices, 1, sci.IndexedSeq(1, 2, 3))
+    val m = BootstrapModel(ModelId(4, "def"), polices, null, sci.IndexedSeq(1, 2, 3))
     val m1 = serializeDeserializeRoundTrip(m)
     assertEquals(m, m1)
 
-    val m2 = BootstrapModel(ModelId(4, "def"), polices, 1, sci.IndexedSeq("1", "2", "3"))
+    val m2 = BootstrapModel(ModelId(4, "def"), polices, null, sci.IndexedSeq("1", "2", "3"))
     val m3 = serializeDeserializeRoundTrip(m2)
     assertEquals(m2, m3)
+  }
+
+  @Test def testClosed() {
+    val sub1 = new CloserTesterModel[Int]()
+    val sub2 = new CloserTesterModel[Int]()
+    val subs = sci.IndexedSeq(sub1, sub2)
+    BootstrapModel(ModelId.empty, subs, GenFunc0("", (s: String) => 1l), sci.IndexedSeq(1, 2)).close()
+    subs.foreach(s => assertTrue(s.isClosed))
+  }
+
+  @Test def saltZero() {
+    val m = makeModel(Seq(1, 2, 3), 0)
+    val s = m.getScore()
+    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
+    assertEquals(s._1.right.get, "a")
+  }
+
+  @Test def saltOne() {
+    val m = makeModel(Seq(1, 2, 3), 1)
+    val s = m.getScore()
+    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
+    assertEquals(s._1.right.get, "b")
+  }
+
+  @Test def saltTwo() {
+    val m = makeModel(Seq(1, 2, 3), 2)
+    val s = m.getScore()
+    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
+    assertEquals(s._1.right.get, "c")
+  }
+
+  def makeModel(policies: Iterable[Int], salt: Long): BootstrapModel[Any, String] = {
+    val policyJss = policies.zipWithIndex.map{ p =>
+      s"""
+        | {
+        |   "modelType": "Constant",
+        |   "modelId": {"id": ${p._1 + 1}, "name": ""},
+        |   "value": ${p._2 + 1}
+        | }
+      """.stripMargin
+    }.mkString(",")
+    val js =
+      s"""
+         |{
+         | "modelType": "BootstrapExploration",
+         | "modelId": {"id": 0, "name": ""},
+         | "salt": "$salt",
+         | "policies": [
+         |   $policyJss
+         | ],
+         | "classLabels": ["a", "b", "c"]
+         |}
+      """.stripMargin.parseJson
+    Reader.read(js)
   }
 }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
@@ -1,0 +1,32 @@
+package com.eharmony.aloha.models.exploration
+
+import com.eharmony.aloha.ModelSerializationTestHelper
+import com.eharmony.aloha.id.ModelId
+import com.eharmony.aloha.models.ConstantModel
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits._
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.{immutable => sci}
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+class BootstrapModelTest extends ModelSerializationTestHelper {
+  val polices = sci.IndexedSeq(
+    ConstantModel(Right(1), ModelId(1, "abc")),
+    ConstantModel(Right(2), ModelId(2, "abc")),
+    ConstantModel(Right(1), ModelId(3, "abc"))
+  )
+
+  @Test def testSerialization(): Unit = {
+
+    val m = BootstrapModel(ModelId(4, "def"), polices, 1, sci.IndexedSeq(1, 2, 3))
+    val m1 = serializeDeserializeRoundTrip(m)
+    assertEquals(m, m1)
+
+    val m2 = BootstrapModel(ModelId(4, "def"), polices, 1, sci.IndexedSeq("1", "2", "3"))
+    val m3 = serializeDeserializeRoundTrip(m2)
+    assertEquals(m2, m3)
+  }
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelParserTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelParserTest.scala
@@ -1,0 +1,8 @@
+package com.eharmony.aloha.models.exploration
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+class EpsilonGreedyModelParserTest {
+
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelParserTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelParserTest.scala
@@ -1,8 +1,109 @@
 package com.eharmony.aloha.models.exploration
 
+import com.eharmony.aloha.factory.ModelFactory
+import com.eharmony.aloha.models.{AnySemanticsWithoutFunctionCreation, ConstantModel}
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits._
+import org.junit.Assert._
+import org.junit.Test
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
 /**
   * Created by jmorra on 2/26/16.
   */
 class EpsilonGreedyModelParserTest {
+  private[this] val reader = EpsilonGreedyModel.Parser.modelJsonReader[Any, String](ModelFactory(ConstantModel.parser), Option(AnySemanticsWithoutFunctionCreation))
 
+  @Test def goodModel() {
+    val js =
+    s"""
+      |{
+      | "modelType": "EpsilonGreedyExploration",
+      | "modelId": {"id": 0, "name": ""},
+      | "epsilon": 0.1,
+      | "salt": "0",
+      | "defaultPolicy": {
+      |   "modelType": "Constant",
+      |   "modelId": {"id": 1, "name": ""},
+      |   "value": 1
+      | },
+      | "classLabels": ["a", "b", "c"]
+      |}
+    """.stripMargin.parseJson
+
+    val m = reader.read(js)
+    val s = m(null)
+    assertEquals("a", s.get)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noClassLabels() {
+    val js =
+      """
+        |{
+        | "modelType": "EpsilonGreedyExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "epsilon": 0.1,
+        | "salt": 0,
+        | "defaultPolicy": {
+        |   "modelType": "Constant",
+        |   "modelId": {"id": 1, "name": ""},
+        |   "value": 1
+        | }
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noEpsilon() {
+    val js =
+      """
+        |{
+        | "modelType": "EpsilonGreedyExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "salt": 0,
+        | "defaultPolicy": {
+        |   "modelType": "Constant",
+        |   "modelId": {"id": 1, "name": ""},
+        |   "value": 1
+        | },
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noSalt() {
+    val js =
+      """
+        |{
+        | "modelType": "EpsilonGreedyExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "epsilon": 0.1,
+        | "defaultPolicy": {
+        |   "modelType": "Constant",
+        |   "modelId": {"id": 1, "name": ""},
+        |   "value": 1
+        | },
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
+
+  @Test(expected = classOf[DeserializationException]) def noDefaultPolicy() {
+    val js =
+      """
+        |{
+        | "modelType": "EpsilonGreedyExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "epsilon": 0.1,
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+
+    reader.read(js)
+  }
 }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
@@ -1,0 +1,27 @@
+package com.eharmony.aloha.models.exploration
+
+import com.eharmony.aloha.ModelSerializationTestHelper
+import com.eharmony.aloha.id.ModelId
+import com.eharmony.aloha.models.ConstantModel
+import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits._
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.{immutable => sci}
+
+/**
+  * Created by jmorra on 2/26/16.
+  */
+class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
+  val constantPolicy = ConstantModel(Right(1), ModelId(2, "abc"))
+
+  @Test def testSerialization(): Unit = {
+    val m = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, 1, sci.IndexedSeq(1, 2, 3))
+    val m1 = serializeDeserializeRoundTrip(m)
+    assertEquals(m, m1)
+
+    val m2 = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, 1, sci.IndexedSeq("1", "2", "3"))
+    val m3 = serializeDeserializeRoundTrip(m2)
+    assertEquals(m2, m3)
+  }
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
@@ -1,11 +1,15 @@
 package com.eharmony.aloha.models.exploration
 
 import com.eharmony.aloha.ModelSerializationTestHelper
+import com.eharmony.aloha.factory.ModelFactory
 import com.eharmony.aloha.id.ModelId
-import com.eharmony.aloha.models.ConstantModel
+import com.eharmony.aloha.models.{AnySemanticsWithoutFunctionCreation, CloserTesterModel, ConstantModel}
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits._
+import com.eharmony.aloha.semantics.func.GenFunc0
 import org.junit.Assert._
 import org.junit.Test
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 import scala.collection.{immutable => sci}
 
@@ -13,15 +17,59 @@ import scala.collection.{immutable => sci}
   * Created by jmorra on 2/26/16.
   */
 class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
-  val constantPolicy = ConstantModel(Right(1), ModelId(2, "abc"))
+  private[this] val reader = EpsilonGreedyModel.Parser.modelJsonReader[Any, String](ModelFactory(ConstantModel.parser), Option(AnySemanticsWithoutFunctionCreation))
+  private[this] val delta = 0.00001f
+  implicit val audit = true
 
-  @Test def testSerialization(): Unit = {
-    val m = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, 1, sci.IndexedSeq(1, 2, 3))
+  @Test def testSerialization() {
+    val constantPolicy = ConstantModel(Right(1), ModelId(2, "abc"))
+    val m = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, null, sci.IndexedSeq(1, 2, 3))
     val m1 = serializeDeserializeRoundTrip(m)
     assertEquals(m, m1)
 
-    val m2 = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, 1, sci.IndexedSeq("1", "2", "3"))
+    val m2 = EpsilonGreedyModel(ModelId(3, "def"), constantPolicy, 0.1f, null, sci.IndexedSeq("1", "2", "3"))
     val m3 = serializeDeserializeRoundTrip(m2)
     assertEquals(m2, m3)
+  }
+
+  @Test def testClosed() {
+    val sub = new CloserTesterModel[Int]()
+    EpsilonGreedyModel(ModelId.empty, sub, 0.1f, GenFunc0("", (s: String) => 1l), sci.IndexedSeq(1, 2)).close()
+    assertTrue(sub.isClosed)
+  }
+
+  @Test def random() {
+    val epsilon = 0.9f
+    val m = makeModel(1, epsilon, 1)
+    val s = m.getScore()
+    assertEquals(s._2.get.getScore.getProbability, epsilon / 3, delta)
+    assertEquals(s._1.right.get, "b")
+  }
+
+  @Test def policy() {
+    val epsilon = 0.1f
+    val m = makeModel(1, epsilon, 0)
+    val s = m.getScore()
+    assertEquals(s._2.get.getScore.getProbability, 1 - epsilon + epsilon / 3, delta)
+    assertEquals(s._1.right.get, "a")
+  }
+
+  def makeModel(policyValue: Int, epsilon: Float, salt: Long): EpsilonGreedyModel[Any, String] = {
+    val js =
+      s"""
+        |{
+        | "modelType": "EpsilonGreedyExploration",
+        | "modelId": {"id": 0, "name": ""},
+        | "epsilon": $epsilon,
+        | "salt": "$salt",
+        | "defaultPolicy": {
+        |   "modelType": "Constant",
+        |   "modelId": {"id": 1, "name": ""},
+        |   "value": $policyValue
+        | },
+        | "classLabels": ["a", "b", "c"]
+        |}
+      """.stripMargin.parseJson
+    reader.read(js)
   }
 }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
@@ -41,7 +41,7 @@ class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
   @Test def random() {
     val epsilon = 0.9f
     val m = makeModel(1, epsilon, 1)
-    val s = m.getScore()
+    val s = m.getScore(null)
     assertEquals(s._2.get.getScore.getProbability, epsilon / 3, delta)
     assertEquals(s._1.right.get, "b")
   }
@@ -49,7 +49,7 @@ class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
   @Test def policy() {
     val epsilon = 0.1f
     val m = makeModel(1, epsilon, 0)
-    val s = m.getScore()
+    val s = m.getScore(null)
     assertEquals(s._2.get.getScore.getProbability, 1 - epsilon + epsilon / 3, delta)
     assertEquals(s._1.right.get, "a")
   }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/util/rand/IntAliasMethodSamplerTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/util/rand/IntAliasMethodSamplerTest.scala
@@ -18,7 +18,7 @@ class IntAliasMethodSamplerTest {
     /** Distributions that gave previous alias method sampling implementation problems.
       */
     @Test def testAccuracyHardDistributions() {
-        val numSamples = 500000
+        val numSamples = 100000
 
         val distributions = Seq(
             normalize(List.fill(1)(1)),
@@ -48,7 +48,7 @@ class IntAliasMethodSamplerTest {
       * after it's probability is increased.
       */
     @Test def test2ClassDistribution() {
-        val numRandomSamples = 1000
+        val numRandomSamples = 500
         val prGranularity: Int = 97 // Sum prime
         val rand = new scala.util.Random(1)
 
@@ -77,7 +77,7 @@ class IntAliasMethodSamplerTest {
 
     @Test def testRandom2ClassDistribution() {
         val rand = new scala.util.Random(2)
-        (1 to 500000).foreach(_ => test(2, 2, rand))
+        (1 to 100000).foreach(_ => test(2, 2, rand))
     }
 
     /** Sadly, this doesn't work.  We'd like to be able to guarantee this but it'll require an algorithm change that

--- a/aloha-core/src/test/scala/com/eharmony/aloha/util/rand/IntAliasMethodSamplerTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/util/rand/IntAliasMethodSamplerTest.scala
@@ -18,7 +18,7 @@ class IntAliasMethodSamplerTest {
     /** Distributions that gave previous alias method sampling implementation problems.
       */
     @Test def testAccuracyHardDistributions() {
-        val numSamples = 1000000
+        val numSamples = 500000
 
         val distributions = Seq(
             normalize(List.fill(1)(1)),
@@ -77,7 +77,7 @@ class IntAliasMethodSamplerTest {
 
     @Test def testRandom2ClassDistribution() {
         val rand = new scala.util.Random(2)
-        (1 to 1000000).foreach(_ => test(2, 2, rand))
+        (1 to 500000).foreach(_ => test(2, 2, rand))
     }
 
     /** Sadly, this doesn't work.  We'd like to be able to guarantee this but it'll require an algorithm change that

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.0.1</version>
+                <version>2.4</version>
             </dependency>
 
             <dependency>

--- a/src/site/markdown/model_formats.md
+++ b/src/site/markdown/model_formats.md
@@ -2386,8 +2386,8 @@ is used as a lookup into the `classLabels`.
     },
     {
       "import": "file:///x/y/a.json"
-    },
-  ]
+    }
+  ],
   "classLabels": [1, 2, 3]
 }
 ```

--- a/src/site/markdown/model_formats.md
+++ b/src/site/markdown/model_formats.md
@@ -45,6 +45,10 @@ This is just a suggestion but it will pay huge dividends in terms of cleaner dat
 * [Vowpal Wabbit model](#Vowpal_Wabbit_model): a model exposing [VW](https://github.com/JohnLangford/vowpal_wabbit/wiki) 
   through its [JNI](https://github.com/JohnLangford/vowpal_wabbit/tree/master/java) wrapper
 * [H<sub>2</sub>O model](#H2O_model): a model exposing the suite of [H<sub>2</sub>O](https://h2o.ai) models
+* [Epsilon greedy exploration model](#Epsilon_greedy_exploration_model): a model for doing 
+  [epsilon greedy](https://en.wikipedia.org/wiki/Multi-armed_bandit) style exploration.
+* [Bootstrap exploration model](#Bootstrap_exploration_model): a model for doing
+  exploration over a number of policies.
 
 
 ## Categorical distribution model
@@ -2179,5 +2183,211 @@ default is provided and that default is returned, it is not counted as a missing
     "Circumference (unused)":  "Pi * ${diameter}"
   },
   "modelUrl": "res:com/eharmony/aloha/models/h2o/glm_afa04e31_17ad_4ca6_9bd1_8ab80005ce38.java"
+}
+```
+
+## Epsilon greedy exploration model
+
+An epsilon greedy exploration model is a model used for exploring over a set of actions in 
+[bandit](https://en.wikipedia.org/wiki/Multi-armed_bandit) and
+[reinforcement learning](https://en.wikipedia.org/wiki/Reinforcement_learning) style problems.  Epsilon greedy makes
+use of a parameter called epsilon and a default policy.  The model will choose a random action with probability `epsilon`
+and an action from the default policy with probability `1 - epsilon`.
+
+### (EG) JSON Fields
+
+<table>
+  <tr>
+    <th>Field Name</th>
+    <th>JSON Type</th>
+    <th>JSON Subtype</th>
+    <th>Required</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><a href="#aEG_modelType">modelType</a></td>
+    <td>String</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td>modelId</td>
+    <td>Object</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aEG_salt">salt</a></td>
+    <td>String</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aEG_epsilon">epsilon</a></td>
+    <td>Number</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aEG_default_policy">defaultPolicy</a></td>
+    <td>Object</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aEG_class_labels">classLabels</a></td>
+    <td>Array</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+</table>
+
+### (EG) JSON Field Descriptions
+
+#### (EG) modelType
+
+`modelType` field must be `EpsilonGreedyExploration`.
+
+#### (EG) salt
+
+`salt` is an Aloha specification that will produce a `Long` that will be used as the salt for the randomization.  This 
+allows the randomization to be repeatable.
+
+#### (EG) epsilon
+
+`epsilon` is a floating point number which signifies the tradeoff between exploration and exploitation.  Actions are
+chosen at random with probability `epsilon` and from the default policy with probability `1 - epsilon`.
+
+#### (EG) default policy
+
+`defaultPolicy` is the model to be used to return the learned action.  This model must evaluate to an `Int` as it is 
+used within the
+[MWT Epsilon Greedy Explorer](https://github.com/multiworldtesting/explore-java/blob/master/src/main/java/com/mwt/explorers/EpsilonGreedyExplorer.java).
+
+#### (EG) class labels
+
+`classLabels` is an array of the output type of the model.  The result from either the default policy or the random action
+is used as a lookup into the `classLabels`.
+
+### (EG) JSON Examples
+
+```json
+{
+  "modelType": "EpsilonGreedyExploration",
+  "modelId": {
+    "id": 1,
+    "name": "Epsilon Greedy Model"
+  },
+  "epsilon": 0.1,
+  "salt": "${profile.user_id}",
+  "defaultPolicy": {
+    "import": "file:///x/y/z.json"
+  },
+  "classLabels": [1, 2, 3]
+}
+```
+
+## Bootstrap exploration model
+
+A bootstrap exploration model is a model used for exploring over a set of actions in 
+[bandit](https://en.wikipedia.org/wiki/Multi-armed_bandit) and
+[reinforcement learning](https://en.wikipedia.org/wiki/Reinforcement_learning) style problems.  Bootstrap works over a
+set of policies.  The algorithm chooses one policy at random and uses that policy's action as the chosen action.
+
+### (B) JSON Fields
+
+<table>
+  <tr>
+    <th>Field Name</th>
+    <th>JSON Type</th>
+    <th>JSON Subtype</th>
+    <th>Required</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><a href="#aB_modelType">modelType</a></td>
+    <td>String</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td>modelId</td>
+    <td>Object</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aB_salt">salt</a></td>
+    <td>String</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aB_default_policy">policies</a></td>
+    <td>Array</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+  <tr>
+    <td><a href="#aB_class_labels">classLabels</a></td>
+    <td>Array</td>
+    <td>N / A</td>
+    <td>true</td>
+    <td>N / A</td>
+  </tr>
+</table>
+
+### (B) JSON Field Descriptions
+
+#### (B) modelType
+
+`modelType` field must be `BootstrapExploration`.
+
+#### (B) salt
+
+`salt` is an Aloha specification that will produce a `Long` that will be used as the salt for the randomization.  This 
+allows the randomization to be repeatable.
+
+
+#### (B) policies
+
+`policies` are the models to be used to return the action.  All the models must evaluate to an `Int` as it is 
+used within the
+[MWT Bootstrap Explorer](https://github.com/multiworldtesting/explore-java/blob/master/src/main/java/com/mwt/explorers/BootstrapExplorer.java).
+
+#### (B) class labels
+
+`classLabels` is an array of the output type of the model.  The result from either the default policy or the random action
+is used as a lookup into the `classLabels`.
+
+### (B) JSON Examples
+
+```json
+{
+  "modelType": "BootstrapExploration",
+  "modelId": {
+    "id": 1,
+    "name": "Bootstrap Exploration Model"
+  },
+  "salt": "${profile.user_id}",
+  "policies": [
+    {
+      "import": "file:///x/y/z.json"
+    },
+    {
+      "import": "file:///x/y/a.json"
+    },
+  ]
+  "classLabels": [1, 2, 3]
 }
 ```


### PR DESCRIPTION
This is the code to make use of [explore-java](https://github.com/multiworldtesting/explore-java) for Epsilon Greedy and Bootstrap models.  It should be notes that this won't compile now as the MWT code isn't in maven central.  As a result we need to decide upon how we want to handle this.
