### PR TITLE
85 exploration sub scores

### DIFF
--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -5,7 +5,6 @@ import com.eharmony.aloha.id.ModelIdentity
 import com.eharmony.aloha.models.{BaseModel, Model}
 import com.eharmony.aloha.score.Scores.Score
 import com.eharmony.aloha.score.basic.ModelOutput
-import com.eharmony.aloha.score.conversions.RelaxedConversions._
 import com.eharmony.aloha.score.conversions.ScoreConverter
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
 import com.eharmony.aloha.semantics.Semantics
@@ -77,12 +76,18 @@ case class BootstrapModel[A, B](
     models: sci.IndexedSeq[Model[A, Int]],
     subScores: Seq[Score] = Seq.empty,
     successes: sci.IndexedSeq[Int] = sci.IndexedSeq.empty)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
+
+    // If models is empty then all models returned success.
     if (models.isEmpty) {
       val decision = explorer.chooseAction(salt(a), successes)
       val action = decision.getAction
+
+      // We want to return only those subscores that contributed to the chosen action.  Hence
+      // we're going to filter out those successes (in this case actions) that are not the same
+      // as the action chosen by the explorer.
       success(
         score = classLabels(action - 1),
-        subScores = subScores.filter(x => asInt(x).map(_ == action).exists(identity)),
+        subScores = subScores.zip(successes).collect{ case (ss, s) if s == action => ss },
         probability = Option(decision.getProbability)
       )
     }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -4,8 +4,8 @@ import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderComp
 import com.eharmony.aloha.id.ModelIdentity
 import com.eharmony.aloha.models.{BaseModel, Model}
 import com.eharmony.aloha.score.Scores.Score
-import com.eharmony.aloha.score.Scores.Score.IntScore
 import com.eharmony.aloha.score.basic.ModelOutput
+import com.eharmony.aloha.score.conversions.RelaxedConversions._
 import com.eharmony.aloha.score.conversions.ScoreConverter
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
 import com.eharmony.aloha.semantics.Semantics
@@ -79,10 +79,10 @@ case class BootstrapModel[A, B](
     successes: sci.IndexedSeq[Int] = sci.IndexedSeq.empty)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
     if (models.isEmpty) {
       val decision = explorer.chooseAction(salt(a), successes)
-      val usedSubScores = subScores.filter(_.getScore.getExtension(IntScore.impl).getScore == decision.getAction)
+      val action = decision.getAction
       success(
-        score = classLabels(decision.getAction - 1),
-        subScores = usedSubScores,
+        score = classLabels(action - 1),
+        subScores = subScores.filter(x => asInt(x).map(_ == action).exists(identity)),
         probability = Option(decision.getProbability)
       )
     }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -79,9 +79,10 @@ case class BootstrapModel[A, B](
     successes: sci.IndexedSeq[Int] = sci.IndexedSeq.empty)(implicit audit: Boolean): (ModelOutput[B], Option[Score]) = {
     if (models.isEmpty) {
       val decision = explorer.chooseAction(salt(a), successes)
+      val usedSubScores = subScores.filter(_.getScore.getExtension(IntScore.impl).getScore == decision.getAction)
       success(
         score = classLabels(decision.getAction - 1),
-        subScores = subScores.filter(_.getScore.getExtension(IntScore.impl) == classLabels(decision.getAction - 1)),
+        subScores = usedSubScores,
         probability = Option(decision.getProbability)
       )
     }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/BootstrapModel.scala
@@ -4,6 +4,7 @@ import com.eharmony.aloha.factory.{ModelFactory, ModelParser, ParserProviderComp
 import com.eharmony.aloha.id.ModelIdentity
 import com.eharmony.aloha.models.{BaseModel, Model}
 import com.eharmony.aloha.score.Scores.Score
+import com.eharmony.aloha.score.Scores.Score.IntScore
 import com.eharmony.aloha.score.basic.ModelOutput
 import com.eharmony.aloha.score.conversions.ScoreConverter
 import com.eharmony.aloha.score.conversions.ScoreConverter.Implicits.IntScoreConverter
@@ -80,7 +81,7 @@ case class BootstrapModel[A, B](
       val decision = explorer.chooseAction(salt(a), successes)
       success(
         score = classLabels(decision.getAction - 1),
-        subScores = subScores,
+        subScores = subScores.filter(_.getScore.getExtension(IntScore.impl) == classLabels(decision.getAction - 1)),
         probability = Option(decision.getProbability)
       )
     }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -65,9 +65,10 @@ case class EpsilonGreedyModel[A, B](
       {case (e, m) => failure(e, m, os)},
       o => {
         val decision = explorer.chooseAction(salt(a), o)
+        val action = decision.getAction
         success(
-          score = classLabels(decision.getAction - 1),
-          subScores = if (decision.getAction == o) os else None,
+          score = classLabels(action - 1),
+          subScores = if (o == action) os else None,
           probability = Option(decision.getProbability)
         )
       }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModel.scala
@@ -66,9 +66,13 @@ case class EpsilonGreedyModel[A, B](
       o => {
         val decision = explorer.chooseAction(salt(a), o)
         val action = decision.getAction
+
+        // We only want to add the subscore of the default policy if that policy returns the
+        // same action as the one chosen by the explorer.  This allows the differentiation of the explore
+        // and exploit groups using the subscores.
         success(
           score = classLabels(action - 1),
-          subScores = if (o == action) os else None,
+          subScores = os.filter(_ => o == action),
           probability = Option(decision.getProbability)
         )
       }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
@@ -46,24 +46,37 @@ class BootstrapModelTest extends ModelSerializationTestHelper {
   }
 
   @Test def saltZero() {
-    val m = makeModel(Seq(1, 2, 3), 0)
+    val m = makeModel(Seq(1, 2, 3, 3), 0)
     val s = m.getScore(null)
-    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
-    assertEquals(s._1.right.get, "a")
-  }
-
-  @Test def saltOne() {
-    val m = makeModel(Seq(1, 2, 3), 1)
-    val s = m.getScore(null)
-    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
-    assertEquals(s._1.right.get, "b")
-  }
-
-  @Test def saltTwo() {
-    val m = makeModel(Seq(1, 2, 3), 2)
-    val s = m.getScore(null)
-    assertEquals(s._2.get.getScore.getProbability, 1f / 3, delta)
+    val score = s._2.get
+    val subScores = score.getSubScoresList
+    assertEquals(score.getScore.getProbability, 0.5f, delta)
     assertEquals(s._1.right.get, "c")
+    assertEquals(2, subScores.size)
+    assertEquals("model: 3", subScores.get(0).getScore.getModel.getName)
+    assertEquals("model: 4", subScores.get(1).getScore.getModel.getName)
+  }
+
+  @Test def saltSix() {
+    val m = makeModel(Seq(1, 2, 3, 3), 6)
+    val s = m.getScore(null)
+    val score = s._2.get
+    val subScores = score.getSubScoresList
+    assertEquals(score.getScore.getProbability, 0.25f, delta)
+    assertEquals(s._1.right.get, "a")
+    assertEquals(1, subScores.size)
+    assertEquals("model: 1", subScores.get(0).getScore.getModel.getName)
+  }
+
+  @Test def saltFive() {
+    val m = makeModel(Seq(1, 2, 3, 3), 5)
+    val s = m.getScore(null)
+    val score = s._2.get
+    val subScores = score.getSubScoresList
+    assertEquals(score.getScore.getProbability, 0.25f, delta)
+    assertEquals(s._1.right.get, "b")
+    assertEquals(1, subScores.size)
+    assertEquals("model: 2", subScores.get(0).getScore.getModel.getName)
   }
 
   def makeModel(policies: Iterable[Int], salt: Long): BootstrapModel[Any, String] = {
@@ -71,8 +84,8 @@ class BootstrapModelTest extends ModelSerializationTestHelper {
       s"""
         | {
         |   "modelType": "Constant",
-        |   "modelId": {"id": ${p._1 + 1}, "name": ""},
-        |   "value": ${p._2 + 1}
+        |   "modelId": {"id": ${p._2 + 1}, "name": "model: ${p._2 + 1}"},
+        |   "value": ${p._1}
         | }
       """.stripMargin
     }.mkString(",")

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/BootstrapModelTest.scala
@@ -45,36 +45,46 @@ class BootstrapModelTest extends ModelSerializationTestHelper {
     subs.foreach(s => assertTrue(s.isClosed))
   }
 
+  // Using salts 0, 5, 6 because they illicit all three actions in this particular case.
+
+  val subPolicies = Seq(1, 2, 3, 3)
+
+  /**
+    * This test will create a Bootstrap model with 4 constant policies.  Those policies will return (in order) action
+    * 1, 2, 3, and 3.  By setting the salt to 0 we ensure that the explorer chooses EITHER policy 3 or 4.  Because both
+    * of those policies return the same action the probability should be 2/4.  We also make sure that the sub scores
+    * are recorded for ONLY those policies that had the same action as the one returned by the explorer.
+    */
   @Test def saltZero() {
-    val m = makeModel(Seq(1, 2, 3, 3), 0)
+    val m = makeModel(subPolicies, 0)
     val s = m.getScore(null)
     val score = s._2.get
     val subScores = score.getSubScoresList
-    assertEquals(score.getScore.getProbability, 0.5f, delta)
-    assertEquals(s._1.right.get, "c")
+    assertEquals(0.5f, score.getScore.getProbability, delta)
+    assertEquals("c", s._1.right.get)
     assertEquals(2, subScores.size)
     assertEquals("model: 3", subScores.get(0).getScore.getModel.getName)
     assertEquals("model: 4", subScores.get(1).getScore.getModel.getName)
   }
 
   @Test def saltSix() {
-    val m = makeModel(Seq(1, 2, 3, 3), 6)
+    val m = makeModel(subPolicies, 6)
     val s = m.getScore(null)
     val score = s._2.get
     val subScores = score.getSubScoresList
-    assertEquals(score.getScore.getProbability, 0.25f, delta)
-    assertEquals(s._1.right.get, "a")
+    assertEquals(0.25f, score.getScore.getProbability, delta)
+    assertEquals("a", s._1.right.get)
     assertEquals(1, subScores.size)
     assertEquals("model: 1", subScores.get(0).getScore.getModel.getName)
   }
 
   @Test def saltFive() {
-    val m = makeModel(Seq(1, 2, 3, 3), 5)
+    val m = makeModel(subPolicies, 5)
     val s = m.getScore(null)
     val score = s._2.get
     val subScores = score.getSubScoresList
-    assertEquals(score.getScore.getProbability, 0.25f, delta)
-    assertEquals(s._1.right.get, "b")
+    assertEquals(0.25f, score.getScore.getProbability, delta)
+    assertEquals("b", s._1.right.get)
     assertEquals(1, subScores.size)
     assertEquals("model: 2", subScores.get(0).getScore.getModel.getName)
   }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
@@ -56,6 +56,8 @@ class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
     assertEquals(epsilon / m.classLabels.size, score.getScore.getProbability, delta)
     assertEquals(m.classLabels(action - 1), s._1.right.get)
     assertEquals("b", s._1.right.get)
+
+    // The lack of subscores indicates that the default policy was NOT recorded when doing exploration.
     assertTrue(score.getSubScoresList.isEmpty)
   }
 

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/exploration/EpsilonGreedyModelTest.scala
@@ -52,17 +52,23 @@ class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
     val action = random.uniformInt(1, m.classLabels.size)
 
     val s = m.getScore(null)
-    assertEquals(epsilon / m.classLabels.size, s._2.get.getScore.getProbability, delta)
+    val score = s._2.get
+    assertEquals(epsilon / m.classLabels.size, score.getScore.getProbability, delta)
     assertEquals(m.classLabels(action - 1), s._1.right.get)
     assertEquals("b", s._1.right.get)
+    assertTrue(score.getSubScoresList.isEmpty)
   }
 
   @Test def policy() {
     val epsilon = 0f
     val m = makeModel(1, epsilon, 0)
     val s = m.getScore(null)
-    assertEquals(1 - epsilon + epsilon / m.classLabels.size, s._2.get.getScore.getProbability, delta)
+
+    val score = s._2.get
+    assertEquals(1 - epsilon + epsilon / m.classLabels.size, score.getScore.getProbability, delta)
     assertEquals("a", s._1.right.get)
+    assertEquals(1, score.getSubScoresCount)
+    assertEquals("defaultPolicy", score.getSubScores(0).getScore.getModel.getName)
   }
 
   def makeModel(policyValue: Int, epsilon: Float, salt: Long): EpsilonGreedyModel[Any, String] = {
@@ -75,7 +81,7 @@ class EpsilonGreedyModelTest extends ModelSerializationTestHelper {
         | "salt": "$salt",
         | "defaultPolicy": {
         |   "modelType": "Constant",
-        |   "modelId": {"id": 1, "name": ""},
+        |   "modelId": {"id": 1, "name": "defaultPolicy"},
         |   "value": $policyValue
         | },
         | "classLabels": ["a", "b", "c"]


### PR DESCRIPTION
This will update sub score recording to only record those sub scores when using exploration type models if the sub model was actually used.  This is important because it allows evaluating the exploration model policies independently.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eharmony/aloha/86)

<!-- Reviewable:end -->
