### PR TITLE
99 h2o serialization

### DIFF
--- a/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/H2oModel.scala
+++ b/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/H2oModel.scala
@@ -45,7 +45,7 @@ final case class H2oModel[-A, +B](
   extends BaseModel[A, B]
      with Logging {
 
-  // Because H2o's RowData object is essentially a Map of String to Object, we unapply the wrapper
+  // Because H2O's RowData object is essentially a Map of String to Object, we unapply the wrapper
   // and throw away the type information on the function return type.  We have type safety because
   // FeatureFunction is sealed (ADT).
   @transient private[this] lazy val lazyAnyRefFF = featureFunctions map {


### PR DESCRIPTION
This change now constructs the H2O model with the `GenModel` already made.  This is advantageous because when moving the models between machines it makes use of the same `classCacheDir` that is used for the Aloha feature functions.  This means that if that directory is uploaded to the cluster than the whole H2O model will work correctly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eharmony/aloha/100)

<!-- Reviewable:end -->
