### PR TITLE
Providing fix for compiling H2O models with custom classloader

### DIFF
--- a/aloha-h2o/pom.xml
+++ b/aloha-h2o/pom.xml
@@ -24,6 +24,7 @@
 
     <properties>
         <h2o.version>3.8.2.3</h2o.version>
+        <h2o.genmodel.artifact>h2o-genmodel</h2o.genmodel.artifact>
     </properties>
 
     <dependencies>
@@ -59,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>ai.h2o</groupId>
-            <artifactId>h2o-genmodel</artifactId>
+            <artifactId>${h2o.genmodel.artifact}</artifactId>
             <version>${h2o.version}</version>
             <exclusions>
                 <exclusion>
@@ -103,6 +104,26 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.3</version>
                 <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/classes</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>h2o_mvn.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-test-resources</id>
                         <phase>process-test-resources</phase>

--- a/aloha-h2o/src/main/resources/h2o_mvn.properties
+++ b/aloha-h2o/src/main/resources/h2o_mvn.properties
@@ -1,0 +1,1 @@
+h2oGenModelName=${h2o.genmodel.artifact}-${h2o.version}.jar

--- a/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/H2oModel.scala
+++ b/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/H2oModel.scala
@@ -1,6 +1,6 @@
 package com.eharmony.aloha.models.h2o
 
-import java.io.{File, StringReader}
+import java.io.File
 import java.net.{URL, URLClassLoader}
 import java.util.Properties
 
@@ -27,13 +27,12 @@ import hex.genmodel.GenModel
 import hex.genmodel.easy.exception.PredictUnknownCategoricalLevelException
 import hex.genmodel.easy.{EasyPredictModelWrapper, RowData}
 import org.apache.commons.codec.binary.Base64
-import spray.json._
 import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.json._
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.collection.{immutable => sci}
-import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 /**

--- a/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/compiler/Compiler.scala
+++ b/aloha-h2o/src/main/scala/com/eharmony/aloha/models/h2o/compiler/Compiler.scala
@@ -1,7 +1,7 @@
 package com.eharmony.aloha.models.h2o.compiler
 
 import java.io.File
-import java.net.{URL, URLClassLoader}
+import java.net.URLClassLoader
 import java.nio.charset.Charset
 import java.util.Locale
 import javax.tools.JavaCompiler.CompilationTask


### PR DESCRIPTION
Compiling H2O models within Jetty proved unsuccessful.  The reason for this is that Jetty has its own classloader.  A workaround for this is to find the `h2o-genmodel` jar within the current Thread's classloader.  While this will fix the specific need of compiling H2O models within Jetty, it should also provide a more general framework for dealing with custom classloaders.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eharmony/aloha/108)

<!-- Reviewable:end -->
