### PR TITLE
Closes #131

### DIFF
--- a/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelFactory.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/factory/ModelFactory.scala
@@ -24,12 +24,12 @@ import scala.util.{Failure, Success, Try}
   * @tparam A model input type
   * @tparam B Model output type
   */
-abstract class ModelFactory[A, B] extends ReadableByString[Try[Model[A, B]]]
-                                     with GZippedReadable[Try[Model[A, B]]]
-                                     with LocationLoggingReadable[Try[Model[A, B]]]
-                                     with MultipleAlohaReadable[Try[Model[A, B]]]
-                                     with SequenceMultipleReadable[ReadableSource, Try, Model[A, B]]
-                                     with Logging
+sealed abstract class ModelFactory[A, B] extends ReadableByString[Try[Model[A, B]]]
+                                            with GZippedReadable[Try[Model[A, B]]]
+                                            with LocationLoggingReadable[Try[Model[A, B]]]
+                                            with MultipleAlohaReadable[Try[Model[A, B]]]
+                                            with SequenceMultipleReadable[ReadableSource, Try, Model[A, B]]
+                                            with Logging
 
 /**
   * A `ModelFactory` is responsible for creating models from model specifications.

--- a/aloha-core/src/test/java/com/eharmony/aloha/factory/JavaDefaultModelFactoryTest.java
+++ b/aloha-core/src/test/java/com/eharmony/aloha/factory/JavaDefaultModelFactoryTest.java
@@ -61,7 +61,7 @@ public class JavaDefaultModelFactoryTest {
      */
     private static final String[] PARSER_NAMES;
 
-    private static final ModelFactory<TreeAuditor.Tree<?>, Double, Map<String, Long>, TreeAuditor.Tree<Double>> defaultFactory;
+    private static final ModelFactoryImpl<TreeAuditor.Tree<?>, Double, Map<String, Long>, TreeAuditor.Tree<Double>> defaultFactory;
 
     static {
         String[] names = new String[] {

--- a/aloha-core/src/test/java/com/eharmony/aloha/models/conversion/DoubleToLongJavaTest.java
+++ b/aloha-core/src/test/java/com/eharmony/aloha/models/conversion/DoubleToLongJavaTest.java
@@ -18,7 +18,7 @@ public class DoubleToLongJavaTest {
 
     @Test
     public void test() {
-        final ModelFactory<TreeAuditor.Tree<?>, Long, Object, TreeAuditor.Tree<Long>> factory = getJavaLongFactory();
+        final ModelFactory<Object, TreeAuditor.Tree<Long>> factory = getJavaLongFactory();
         final String json = goodJson();
         final Try<Model<Object, TreeAuditor.Tree<Long>>> modelTry = factory.fromString(json);
 

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/conversion/DoubleToLongModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/conversion/DoubleToLongModelTest.scala
@@ -118,7 +118,7 @@ object DoubleToLongModelTest {
     private val scalaFactory = ModelFactory.defaultFactory(semantics, TreeAuditor[Long]())
     private val javaFactory = ModelFactory.defaultFactory(semantics, TreeAuditor[jl.Long]())
 
-    def getScalaLongFactory: ModelFactory[Tree[_], Long, Any, Tree[Long]] = scalaFactory
+    def getScalaLongFactory: ModelFactory[Any, Tree[Long]] = scalaFactory
     def getJavaLongFactory = javaFactory
 
     private implicit def intToOptLong(a: Int): Option[Long] = Option(a)

--- a/aloha-h2o/src/test/scala/com/eharmony/aloha/models/h2o/H2oModelTest.scala
+++ b/aloha-h2o/src/test/scala/com/eharmony/aloha/models/h2o/H2oModelTest.scala
@@ -287,7 +287,7 @@ object H2oModelTest {
     semantics
   }
 
-  private def ProtoFactory[N: RefInfo]: ModelFactory[Tree[_], N, Abalone, Tree[N]] = ModelFactory.defaultFactory(protoSemantics, TreeAuditor[N]())
+  private def ProtoFactory[N: RefInfo]: ModelFactory[Abalone, Tree[N]] = ModelFactory.defaultFactory(protoSemantics, TreeAuditor[N]())
 
   /**
     * Recreate the h2o model results

--- a/aloha-io-avro/src/main/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactory.scala
+++ b/aloha-io-avro/src/main/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactory.scala
@@ -1,0 +1,42 @@
+package com.eharmony.aloha.factory.avro
+
+import java.io.File
+
+import com.eharmony.aloha.audit.impl.avro.Score
+import com.eharmony.aloha.factory.ModelFactory
+import org.apache.avro.generic.GenericRecord
+
+import scala.util.Try
+
+/**
+  * Created by deak on 3/2/17.
+  */
+object StdAvroModelFactory {
+
+  /**
+    * Provides an easy interface for creating ModelFactory instances that both take and
+    * return Avro objects.
+    * @param modelDomainSchemaVfsUrl an Apache VFS URL pointing to a JSON Avro Schema that
+    *                                represents the data passed to models created by this factory.
+    * @param modelCodomainRefInfoStr A string representation of a `com.eharmony.aloha.reflect.RefInfo`.
+    * @param imports imports to be injected into feature functions synthesized by the factory.
+    * @param classCacheDir a cache directory on the local machine used to cache class files of
+    *                      the created feature functions used in the models produced by the
+    *                      factory.
+    * @param dereferenceAsOptional whether to treat the dereferencing of repeated variables as
+    *                              an optional type.  This avoids index out of bounds exceptions
+    *                              and is safer but slightly slower.
+    * @param useVfs2 use Apache VFS2 to locate the domain schema (true) or use VFS1 (false.
+    * @return A Try of a ModelFactory that creates models taking `GenericRecord` instances as
+    *         input and returns `com.eharmony.aloha.audit.impl.avro.Score` as output.
+    */
+  def apply(modelDomainSchemaVfsUrl: String,
+            modelCodomainRefInfoStr: String,
+            imports: Seq[String] = Nil,
+            classCacheDir: Option[File] = None,
+            dereferenceAsOptional: Boolean = true,
+            useVfs2: Boolean = true): Try[ModelFactory[GenericRecord, Score]] = {
+
+    Try { throw new UnsupportedOperationException }
+  }
+}

--- a/aloha-io-avro/src/main/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactory.scala
+++ b/aloha-io-avro/src/main/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactory.scala
@@ -1,12 +1,20 @@
 package com.eharmony.aloha.factory.avro
 
-import java.io.File
+import java.io.{File, InputStream}
 
-import com.eharmony.aloha.audit.impl.avro.Score
+import com.eharmony.aloha.audit.impl.avro.{AvroScoreAuditor, Score}
 import com.eharmony.aloha.factory.ModelFactory
+import com.eharmony.aloha.factory.ex.AlohaFactoryException
+import com.eharmony.aloha.reflect.{RefInfo, RefInfoOps}
+import com.eharmony.aloha.semantics.compiled.CompiledSemantics
+import com.eharmony.aloha.semantics.compiled.compiler.TwitterEvalCompiler
+import com.eharmony.aloha.semantics.compiled.plugin.avro.CompiledSemanticsAvroPlugin
+import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
+import org.apache.commons.io.IOUtils
 
-import scala.util.Try
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by deak on 3/2/17.
@@ -16,6 +24,11 @@ object StdAvroModelFactory {
   /**
     * Provides an easy interface for creating ModelFactory instances that both take and
     * return Avro objects.
+    *
+    * This is especially useful for creating factories in generic services because the
+    * `modelCodomainRefInfoStr` is a string rather than `RefInfo` so it can come from a
+    * property file.
+    *
     * @param modelDomainSchemaVfsUrl an Apache VFS URL pointing to a JSON Avro Schema that
     *                                represents the data passed to models created by this factory.
     * @param modelCodomainRefInfoStr A string representation of a `com.eharmony.aloha.reflect.RefInfo`.
@@ -37,6 +50,61 @@ object StdAvroModelFactory {
             dereferenceAsOptional: Boolean = true,
             useVfs2: Boolean = true): Try[ModelFactory[GenericRecord, Score]] = {
 
-    Try { throw new UnsupportedOperationException }
+    val f = for {
+      s <- semantics(modelDomainSchemaVfsUrl, useVfs2, imports, classCacheDir, dereferenceAsOptional)
+      ri <- refInfo(modelCodomainRefInfoStr)
+      a <- auditor(ri)
+      mf = ModelFactory.defaultFactory(s, a)(ri)
+    } yield mf
+
+    f match {
+      case s@Success(_) => s
+      case Failure(e) => Failure(new AlohaFactoryException("Problem creating Avro Factory.", e))
+    }
   }
+
+  private[this] def semantics(vfsUrl: String,
+                              useVfs2: Boolean,
+                              imports: Seq[String],
+                              classCacheDir: Option[File],
+                              dereferenceAsOptional: Boolean) = {
+    for {
+      s <- schema(vfsUrl, useVfs2)
+      p = CompiledSemanticsAvroPlugin[GenericRecord](s, dereferenceAsOptional)
+      cs = CompiledSemantics(TwitterEvalCompiler(classCacheDir = classCacheDir), p, imports)
+    } yield cs
+  }
+
+  private[this] def auditor[A](refInfo: RefInfo[A]) =
+    AvroScoreAuditor(refInfo).map(Success.apply).getOrElse(
+      Failure(new AlohaFactoryException(
+        s"Couldn't create AvroScoreAuditor for ${RefInfoOps.toString(refInfo)}")))
+
+
+  private[this] def refInfo(refInfoStr: String) =
+    RefInfo.fromString(refInfoStr) match {
+      case Left(err) => Failure(new AlohaFactoryException(err))
+      case Right(success) => Success(success.asInstanceOf[RefInfo[Any]])
+    }
+
+  private[this] def schemaInputStream(vfsUrl: String, useVfs2: Boolean) =
+    Try {
+      if (useVfs2)
+        org.apache.commons.vfs2.VFS.getManager.resolveFile(vfsUrl).getContent.getInputStream
+      else org.apache.commons.vfs.VFS.getManager.resolveFile(vfsUrl).getContent.getInputStream
+    }
+
+  private[this] def schemaFromIs(is: InputStream) =
+    Try { new Schema.Parser().parse(is) }
+
+  private[this] def schema(vfsUrl: String, useVfs2: Boolean) = {
+    val isTry = schemaInputStream(vfsUrl, useVfs2)
+    val inSchema = for {
+      is <- isTry
+      s <- schemaFromIs(is)
+    } yield s
+    isTry.foreach(IOUtils.closeQuietly)
+    inSchema
+  }
+
 }

--- a/aloha-io-avro/src/test/resources/avro/class7.avpr
+++ b/aloha-io-avro/src/test/resources/avro/class7.avpr
@@ -1,0 +1,10 @@
+{
+  "name": "Class7",
+  "type": "record",
+  "fields": [
+    {
+      "name": "req_str_1",
+      "type": "string"
+    }
+  ]
+}

--- a/aloha-io-avro/src/test/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactoryTest.scala
+++ b/aloha-io-avro/src/test/scala/com/eharmony/aloha/factory/avro/StdAvroModelFactoryTest.scala
@@ -1,0 +1,55 @@
+package com.eharmony.aloha.factory.avro
+
+import com.eharmony.aloha.audit.impl.avro.Score
+import com.eharmony.aloha.factory.ModelFactory
+import com.eharmony.aloha.models.Model
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.commons.io.IOUtils
+import org.apache.commons.vfs2.VFS
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.BlockJUnit4ClassRunner
+
+/**
+  * Created by deak on 3/2/17.
+  */
+@RunWith(classOf[BlockJUnit4ClassRunner])
+class StdAvroModelFactoryTest {
+  @Test def testHappyPath(): Unit = {
+
+    val factory: ModelFactory[GenericRecord, Score] = StdAvroModelFactory(
+      "res:avro/class7.avpr",
+      "Double",
+      Seq("com.eharmony.aloha.feature.BasicFunctions._", "scala.math._")).get
+
+    val model: Model[GenericRecord, Score] = factory.fromString(modelJson).get
+
+    assertEquals(7d, model(record).getValue.asInstanceOf[Double], 0)
+  }
+
+  private[this] def record = {
+    val is = VFS.getManager.resolveFile("res:avro/class7.avpr").getContent.getInputStream
+    val schema = try new Schema.Parser().parse(is) finally IOUtils.closeQuietly(is)
+    val r = new GenericData.Record(schema)
+    r.put("req_str_1", "smart handsome stubborn")
+    r
+  }
+
+  private[this] val modelJson =
+    """
+      |{
+      |  "modelType": "Regression",
+      |  "modelId": { "id": 0, "name": "" },
+      |  "features" : {
+      |    "my_attributes": "${req_str_1}.split(\"\\\\W+\").map(v => (s\"=$v\", 1.0))"
+      |  },
+      |  "weights": {
+      |    "my_attributes=handsome": 1,
+      |    "my_attributes=smart": 2,
+      |    "my_attributes=stubborn": 4
+      |  }
+      |}
+    """.stripMargin
+}

--- a/aloha-io-proto/src/test/java/com/eharmony/aloha/semantics/compiled/plugin/proto/NonSpringJavaTest.java
+++ b/aloha-io-proto/src/test/java/com/eharmony/aloha/semantics/compiled/plugin/proto/NonSpringJavaTest.java
@@ -2,6 +2,7 @@ package com.eharmony.aloha.semantics.compiled.plugin.proto;
 
 import com.eharmony.aloha.audit.impl.TreeAuditor;
 import com.eharmony.aloha.factory.ModelFactory;
+import com.eharmony.aloha.factory.ModelFactoryImpl;
 import com.eharmony.aloha.factory.ModelParser;
 import com.eharmony.aloha.factory.ri2jf.StdRefInfoToJsonFormat;
 import com.eharmony.aloha.models.Model;
@@ -79,7 +80,8 @@ public class NonSpringJavaTest {
 
 		// Construct the factory. Can use one factory for many models so long as
 		// the type parameters are the same.
-		final ModelFactory<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> modelFactory = getModelFactory();
+		final ModelFactoryImpl<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> modelFactory =
+				getModelFactory();
 
 		// Construct the model. Can reuse the models. All models should be
 		// thread safe and lock free.
@@ -118,7 +120,7 @@ public class NonSpringJavaTest {
 	 * @return a model specified by the file.
 	 */
 	private static Model<TestProto, TreeAuditor.Tree<Double>> getModel(
-			ModelFactory<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> modelFactory,
+			ModelFactoryImpl<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> modelFactory,
 			FileObject fo2Model) {
 
 		// THIS CAST IS NECESSARY (even though it might not seem like it):
@@ -159,7 +161,7 @@ public class NonSpringJavaTest {
 	 * 
 	 * @return a factory used to construct models.
 	 */
-	private static ModelFactory<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> getModelFactory() {
+	private static ModelFactoryImpl<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> getModelFactory() {
 
 		// ================================================================================================
 		// Construct the semantics
@@ -224,8 +226,8 @@ public class NonSpringJavaTest {
 		// ================================================================================================
 		final Manifest<Double> refInfo = (Manifest<Double>) RefInfo.fromString("java.lang.Double").right().get();
 
-		final ModelFactory<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> factory =
-			new ModelFactory<>(
+		final ModelFactoryImpl<TreeAuditor.Tree<?>, Double, TestProto, TreeAuditor.Tree<Double>> factory =
+			new ModelFactoryImpl<>(
 				semantics,
 				morphableAuditor,
 				JavaConversions.asScalaBuffer(parsers),


### PR DESCRIPTION
This makes does two things.  First, it changes the current `ModelFactory` to `ModelFactoryImpl` and then creates an abstract base class `ModelFactory` that only has two type parameters.  This is very nice as it simplifies the type signature.

The second thing that it does is to allow the creation of Avro factories very easily.  This can be done without a compiler generated `RefInfo` and instead uses a String representation of a `RefInfo` that is parsed.  I know this is absurd, but the factory method `StdAvroModelFactory.apply` that simplifies the creation of Avro factories returns a `scala.util.Try`  This let's the user do the error handling.