### PR TITLE
Closes #163

### DIFF
--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/MultilabelModel.scala
@@ -18,11 +18,10 @@ import scala.collection.{immutable => sci}
   * Created by ryan.deak on 8/29/17.
   *
   * @param modelId
-  * @param labelInTrainingSet
+  * @param labelsInTrainingSet
   * @param labelsOfInterest
   * @param featureNames
   * @param featureFunctions
-  * @param labelDependentFeatures
   * @param predictorProducer
   * @param auditor
   * @tparam U upper bound on model output type `B`
@@ -30,42 +29,23 @@ import scala.collection.{immutable => sci}
   * @tparam A input type of the model
   * @tparam B output type of the model.
   */
+// TODO: When adding label-dep features, a Seq[GenAggFunc[K, Sparse]] will be needed.
+// TODO: To create a Seq[GenAggFunc[K, Sparse]], a Semantics[K] will need to derived a from Semantics[A].
+// TODO: MorphableSemantics provides this.  If K is *embedded inside* A, it should be possible in some cases.
 case class MultilabelModel[U, K, -A, +B <: U](
     modelId: ModelIdentity,
-    labelInTrainingSet: Seq[K],
+    labelsInTrainingSet: sci.IndexedSeq[K],
 
     labelsOfInterest: Option[GenAggFunc[A, sci.IndexedSeq[K]]],
 
     featureNames: sci.IndexedSeq[String],
     featureFunctions: sci.IndexedSeq[GenAggFunc[A, Sparse]],
 
-    // Here is a problem.  B/C we only have a Semantics[A] (and not a Semantics[K]) in the factory,
-    // we can't produce sci.IndexedSeq[GenAggFunc[K, Sparse]] representing the many feature functions
-    // that will be applied to each label to produce the sparse values.  We CAN produce a
-    // sci.IndexedSeq[GenAggFunc[A, sci.IndexedSeq[Sparse]]] where sci.IndexedSeq[Sparse] is the result
-    // of one feature applied to all applicable labels.  Many feature definitions
-    // are possible and that's why there is a sci.IndexedSeq[GenAggFunc[...]].  But the issue arises
-    // of how to link the indices of sci.IndexedSeq[Sparse] to the indices of labelsOfInterest,
-    // especially if labelsOfInterest is an Option and not required.
-    //
-    // We can have an "honor system" based approach where we kindly ask the caller to behave and make
-    // the sequences line up, but that always seems like a recipe for disaster.
-    //
-    // We could do sci.IndexedSeq[GenAggFunc[A, sci.IndexedSeq[(K, Sparse)]]] and remove the honor
-    // system approach but that seems like a lot of computational overhead.
-    //
-    // It would be nice if we could use MorphableSemantics to change Semantics[A] into Semantics[K]
-    // but this is fraught with problems.  For instance, with the Avro semantics, we have to supply
-    // parameters to create a CompiledSemanticsAvroPlugin.  Therefore, we'd have to use reflection
-    // to see how K relates to A, and it's not guaranteed that K is embedded in A and that K is a
-    // GenericRecord.
-    //
-    labelDependentFeatures: sci.IndexedSeq[GenAggFunc[A, sci.IndexedSeq[Sparse]]],
-
     predictorProducer: SparsePredictorProducer[K],
     auditor: Auditor[U, Map[K, Double], B]
 )
 extends SubmodelBase[U, Map[K, Double], A, B] {
+  import MultilabelModel._
 
   @transient private[this] lazy val predictor = predictorProducer()
 
@@ -74,55 +54,93 @@ extends SubmodelBase[U, Map[K, Double], A, B] {
     predictor
   }
 
-  // TODO: Create the label dependent features once and then select them based on the labels created from the example.
-  // This is going to be very difficult when the label dependent feature functions are produced by the factory
-  // because we don't have a Semantics[K], we only have a semantics[A].  So, if we want to cut down on computation
-  // time, we can cache the features using a scala.collection.concurrent.TrieMap or a
-  // java.util.concurrent.ConcurrentHashMap.  This should be fine AS LONG AS the functions in labelDependentFeatures
-  // are idempotent.  That should be a stated in the documentation for that parameter.
+  private[this] val labelToInd: Map[K, Int] =
+    labelsInTrainingSet.zipWithIndex.map { case (label, i) => label -> i }(collection.breakOut)
 
-  private val globalLdf = labelExtraction match {
-    case KnownLabelExtraction(labels) => Option(applyLdf(labels))
-    case _ => None
-  }
-
-  private[this] def applyLdf(labels: Seq[K]): Seq[sci.IndexedSeq[F]] =
-    labels.map(label => labelDependentFeatures.map(f => f(label)))
 
   override def subvalue(a: A): Subvalue[B, Map[K, Double]] = {
 
-    // Get the labels for which predictions should be produced.
-    val labels = labelExtraction match {
-      case KnownLabelExtraction(constLabels) => constLabels
-      case PerExampleLabelExtraction(extractor) => extractor(a)
-    }
+    // TODO: Is this good enough?  Are we tracking enough missing information?  Probably not.
+    val (indices, labelsToPredict, labelsWithNoPrediction) =
+      labelsOfInterest.map ( labelFn =>
+        labelsForPrediction(a, labelFn, labelToInd)
+      ) getOrElse {
+        (labelsInTrainingSet.indices, labelsInTrainingSet, Seq.empty)
+      }
 
-    // Get the label-dependent features.
-    // TODO: Handle missing data in the extraction process like in RegressionFeatures.constructFeatures
-    val ldf: Seq[sci.IndexedSeq[F]] = globalLdf getOrElse applyLdf(labels)
+    // TODO: Do a better job of tracking missing features like in the RegressionFeatures trait.
+    val features = featureFunctions.map(f => f(a))
 
-    // TODO: Handle missing data in the extraction process like in RegressionFeatures.constructFeatures
-    val features: sci.IndexedSeq[F] = featureExtraction.map(f => f(a))
+    // TODO: If labelsToPredict is empty, don't run predictor.  Return failure and report inside.
 
     // predictor is responsible for getting the data into the correct type and applying
     // it within the underlying ML library to produce a prediction.  The mapping back to
     // (K, Double) pairs is also its responsibility.
-    val natural: Map[K, Double] = predictor(features, labels, ldf)
-    val aud: B = auditor.success(modelId, natural)
+    //
+    // TODO: When supporting label-dependent features, fill in the last parameter with a valid value.
+    // TODO: Consider wrapping in a Try
+    val natural = predictor(features, labelsToPredict, indices, sci.IndexedSeq.empty)
+
+    val errors =
+      if (labelsWithNoPrediction.nonEmpty)
+        Seq(s"Labels provide for which a prediction could not be produced: ${labelsWithNoPrediction.mkString(", ")}.")
+      else Seq.empty
+
+    // TODO: Incorporate missing data reporting.
+    val aud: B = auditor.success(modelId, natural, errorMsgs = errors)
+
     Subvalue(aud, Option(natural))
   }
+
+  override def close(): Unit = predictor.close()
 }
 
 object MultilabelModel extends ParserProviderCompanion {
 
-  object Parser extends ModelParsingPlugin {
-    override val modelType: String = "multilabel"
-    override def modelJsonReader[U, N, A, B <: U](
+  protected[models] def labelsForPrediction[A, K](
+      a: A,
+      labelsOfInterest: GenAggFunc[A, sci.IndexedSeq[K]],
+      labelToInd: Map[K, Int]
+  ): (sci.IndexedSeq[Int], sci.IndexedSeq[K], Seq[K]) = {
+
+    val labelsShouldPredict = labelsOfInterest(a)
+
+    val unsorted =
+      for {
+        label <- labelsShouldPredict
+        ind   <- labelToInd.get(label).toList
+      } yield (ind, label)
+
+    val noPrediction =
+      if (unsorted.size == labelsShouldPredict.size) Seq.empty
+      else labelsShouldPredict.filterNot(labelToInd.contains)
+
+    val (ind, lab) = unsorted.sortBy{ case (i, _) => i }.unzip
+
+    (ind, lab, noPrediction)
+  }
+
+  override def parser: ModelParser = Parser
+
+  object Parser extends ModelSubmodelParsingPlugin {
+    override val modelType: String = "multilabel-sparse"
+
+    // TODO: Figure if a Option[JsonReader[MultilabelModel[U, _, A, B]]] can be returned.
+    // See: parser that returns SegmentationModel[U, _, N, A, B]
+    // See: parser that returns RegressionModel[U, A, B]
+    // Seems like this should be possible but we get the error:
+    //
+    //   [error] method commonJsonReader has incompatible type
+    //   [error]    override def commonJsonReader[U, N, A, B <: U](
+    //   [error]                 ^
+    //
+    override def commonJsonReader[U, N, A, B <: U](
         factory: SubmodelFactory[U, A],
         semantics: Semantics[A],
-        auditor: Auditor[U, N, B]
-    )(implicit r: RefInfo[N], jf: JsonFormat[N]): Option[JsonReader[MultilabelModel[U, _, _, A, B]]] = {
-
+        auditor: Auditor[U, N, B])(implicit
+        r: RefInfo[N],
+        jf: JsonFormat[N]
+    ): Option[JsonReader[_ <: Model[A, B] with Submodel[_, A, B]]] = {
       if (!RefInfoOps.isSubType[N, Map[_, Double]])
         None
       else {
@@ -149,6 +167,4 @@ object MultilabelModel extends ParserProviderCompanion {
       }
     }
   }
-
-  override def parser: ModelParser = Parser
 }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/MultilabelModel.scala
@@ -1,0 +1,108 @@
+package com.eharmony.aloha.models
+
+import com.eharmony.aloha.audit.Auditor
+import com.eharmony.aloha.factory._
+import com.eharmony.aloha.id.ModelIdentity
+import com.eharmony.aloha.reflect.{RefInfo, RefInfoOps}
+import com.eharmony.aloha.semantics.Semantics
+import spray.json.{JsonFormat, JsonReader}
+
+sealed trait LabelExtraction[-A, K]
+final case class KnownLabelExtraction[K](labels: Seq[K]) extends LabelExtraction[Any, K]
+final case class PerExampleLabelExtraction[A, K](extractor: A => Seq[K]) extends LabelExtraction[A, K]
+
+/**
+  * Created by ryan.deak on 8/29/17.
+  *
+  * @param modelId
+  * @param labelExtraction
+  * @param labelDependentFeatures
+  * @param featureExtraction
+  * @param predictorProducer
+  * @param auditor
+  * @tparam U upper bound on model output type `B`
+  * @tparam F type of features produced
+  * @tparam K type of label or class
+  * @tparam A input type of the model
+  * @tparam B output type of the model.
+  */
+case class MultilabelModel[U, F, K, -A, +B <: U](
+    modelId: ModelIdentity,
+    labelExtraction: LabelExtraction[A, K],
+    labelDependentFeatures: Seq[K => F],
+    featureExtraction: Seq[A => F],
+    predictorProducer: () => (Seq[F], Seq[K]) => Map[K, Double],
+    auditor: Auditor[U, Map[K, Double], B]
+)
+extends SubmodelBase[U, Map[K, Double], A, B] {
+
+  @transient private[this] lazy val predictor = predictorProducer()
+
+  {
+    // Force predictor eagerly
+    predictor
+  }
+
+  private val globalLdf = labelExtraction match {
+    case KnownLabelExtraction(labels) => Option(applyLdf(labels))
+    case _ => None
+  }
+
+  private[this] def applyLdf(labels: Seq[K]): Seq[Seq[F]] =
+    labels.map(label => labelDependentFeatures.map(f => f(label)))
+
+  override def subvalue(a: A): Subvalue[B, Map[K, Double]] = {
+    val labels = labelExtraction match {
+      case KnownLabelExtraction(ls) => ls
+      case PerExampleLabelExtraction(extractor) => extractor(a)
+    }
+
+    // Get the label-dependent features.
+    val ldf = globalLdf getOrElse applyLdf(labels)
+
+    val features = featureExtraction.map(f => f(a))
+    val natural = predictor(features, labels)
+    val aud = auditor.success(modelId, natural)
+    Subvalue(aud, Option(natural))
+  }
+}
+
+object MultilabelModel extends ParserProviderCompanion {
+
+  object Parser extends ModelParsingPlugin {
+    override val modelType: String = "multilabel"
+    override def modelJsonReader[U, N, A, B <: U](
+        factory: SubmodelFactory[U, A],
+        semantics: Semantics[A],
+        auditor: Auditor[U, N, B]
+    )(implicit r: RefInfo[N], jf: JsonFormat[N]): Option[JsonReader[MultilabelModel[U, _, _, A, B]]] = {
+
+      if (!RefInfoOps.isSubType[N, Map[_, Double]])
+        None
+      else {
+        // Because N is a subtype of map, it "should" have two type parameters.
+        // This is obviously not true in all cases, like with LongMap
+        // http://scala-lang.org/files/archive/api/2.11.8/#scala.collection.immutable.LongMap
+        // TODO: Make this more robust.
+        val refInfoK = RefInfoOps.typeParams(r).head
+
+        // To allow custom class (key) types, we'll need to create a custom ModelFactoryImpl instance
+        // with a specialized RefInfoToJsonFormat.
+        //
+        // type: Option[JsonFormat[_]]
+        val jsonFormatK = factory.jsonFormat(refInfoK)
+
+        // TODO: parse the label extraction
+
+        // TODO: parse the feature extraction
+
+        // TODO: parse the native submodel from the wrapped ML library.  This involves plugins
+
+
+        ???
+      }
+    }
+  }
+
+  override def parser: ModelParser = Parser
+}

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -30,7 +30,7 @@ import scala.collection.{immutable => sci}
   * @tparam B output type of the model.
   */
 // TODO: When adding label-dep features, a Seq[GenAggFunc[K, Sparse]] will be needed.
-// TODO: To create a Seq[GenAggFunc[K, Sparse]], a Semantics[K] will need to derived a from Semantics[A].
+// TODO: To create a Seq[GenAggFunc[K, Sparse]], a Semantics[K] needs to be derived from a Semantics[A].
 // TODO: MorphableSemantics provides this.  If K is *embedded inside* A, it should be possible in some cases.
 case class MultilabelModel[U, K, -A, +B <: U](
     modelId: ModelIdentity,

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -45,7 +45,9 @@ import scala.util.{Failure, Success, Try}
   * @param predictorProducer the function produced when calling this function is responsible for
   *                          getting the data into the correct type and using it within an
   *                          underlying ML library to produce a prediction.  The mapping back to
-  *                          (K, Double) pairs is also its responsibility.
+  *                          (K, Double) pairs is also its responsibility.  If the predictor
+  *                          produced by predictorProducer is Closeable, it will be closed when
+  *                          MultilabelModel's close method is called.
   * @param numMissingThreshold if provided, we check whether the threshold is exceeded.  If so,
   *                            return an error instead of the computed score.  This is for missing
   *                            data situations.

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -85,6 +85,9 @@ extends SubmodelBase[U, Map[K, Double], A, B]
   @transient private[this] lazy val defaultLabelInfo =
     LabelsAndInfo(labelsInTrainingSet.indices, labelsInTrainingSet, Seq.empty, None)
 
+  /**
+    * Making from label to index into the sequence of all labels encountered during training.
+    */
   private[this] val labelToInd: Map[K, Int] =
     labelsInTrainingSet.zipWithIndex.map { case (label, i) => label -> i }(collection.breakOut)
 

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -1,5 +1,7 @@
 package com.eharmony.aloha.models.multilabel
 
+import java.io.Closeable
+
 import com.eharmony.aloha.audit.Auditor
 import com.eharmony.aloha.dataset.density.Sparse
 import com.eharmony.aloha.factory._
@@ -92,7 +94,11 @@ extends SubmodelBase[U, Map[K, Double], A, B] {
     Subvalue(aud, Option(natural))
   }
 
-  override def close(): Unit = predictor.close()
+  override def close(): Unit =
+    predictor match {
+      case closeable: Closeable => closeable.close()
+      case _ =>
+    }
 }
 
 object MultilabelModel extends ParserProviderCompanion {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -159,7 +159,7 @@ object MultilabelModel extends ParserProviderCompanion {
     * @tparam B
     * @return
     */
-  protected[multilabel] def reportTooManyMissing[U, K, B](
+  protected[multilabel] def reportTooManyMissing[U, K, B <: U](
       modelId: ModelIdentity,
       labelInfo: LabelsAndInfo[K],
       missing: scm.Map[String, Seq[String]],
@@ -180,7 +180,7 @@ object MultilabelModel extends ParserProviderCompanion {
     * @tparam B
     * @return
     */
-  protected[multilabel] def reportNoPrediction[U, K, B](
+  protected[multilabel] def reportNoPrediction[U, K, B <: U](
       modelId: ModelIdentity,
       labelInfo: LabelsAndInfo[K],
       auditor: Auditor[U, Map[K, Double], B]
@@ -202,7 +202,7 @@ object MultilabelModel extends ParserProviderCompanion {
     * @tparam B
     * @return
     */
-  protected[multilabel] def reportSuccess[U, K, B](
+  protected[multilabel] def reportSuccess[U, K, B <: U](
       modelId: ModelIdentity,
       labelInfo: LabelsAndInfo[K],
       missing: scm.Map[String, Seq[String]],
@@ -233,7 +233,7 @@ object MultilabelModel extends ParserProviderCompanion {
     * @tparam B
     * @return
     */
-  protected[multilabel] def reportPredictorError[U, K, B](
+  protected[multilabel] def reportPredictorError[U, K, B <: U](
       modelId: ModelIdentity,
       labelInfo: LabelsAndInfo[K],
       missing: scm.Map[String, Seq[String]],

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -1,10 +1,10 @@
-package com.eharmony.aloha.models
+package com.eharmony.aloha.models.multilabel
 
 import com.eharmony.aloha.audit.Auditor
 import com.eharmony.aloha.dataset.density.Sparse
 import com.eharmony.aloha.factory._
 import com.eharmony.aloha.id.ModelIdentity
-import com.eharmony.aloha.models.multilabel.SparsePredictorProducer
+import com.eharmony.aloha.models._
 import com.eharmony.aloha.reflect.{RefInfo, RefInfoOps}
 import com.eharmony.aloha.semantics.Semantics
 import com.eharmony.aloha.semantics.func.GenAggFunc
@@ -97,7 +97,7 @@ extends SubmodelBase[U, Map[K, Double], A, B] {
 
 object MultilabelModel extends ParserProviderCompanion {
 
-  protected[models] def labelsForPrediction[A, K](
+  protected[multilabel] def labelsForPrediction[A, K](
       a: A,
       labelsOfInterest: GenAggFunc[A, sci.IndexedSeq[K]],
       labelToInd: Map[K, Int]

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -7,46 +7,66 @@ import com.eharmony.aloha.dataset.density.Sparse
 import com.eharmony.aloha.factory._
 import com.eharmony.aloha.id.ModelIdentity
 import com.eharmony.aloha.models._
+import com.eharmony.aloha.models.reg.RegressionFeatures
 import com.eharmony.aloha.reflect.{RefInfo, RefInfoOps}
 import com.eharmony.aloha.semantics.Semantics
-import com.eharmony.aloha.semantics.func.GenAggFunc
+import com.eharmony.aloha.semantics.func.{GenAggFunc, GenAggFuncAccessorProblems}
 import spray.json.{JsonFormat, JsonReader}
 
-import scala.collection.{immutable => sci}
+import scala.collection.{immutable => sci, mutable => scm}
+import scala.util.{Failure, Success, Try}
 
+
+// TODO: When adding label-dep features, a Seq[GenAggFunc[K, Sparse]] will be needed.
+// TODO: To create a Seq[GenAggFunc[K, Sparse]], a Semantics[K] needs to be derived from a Semantics[A].
+// TODO: MorphableSemantics provides this.  If K is *embedded inside* A, it should be possible in some cases.
+// TODO: An alternative is to pass a Map[K, Sparse], Map[K, Option[Sparse]], Map[K, Seq[Sparse]] or something.
+// TODO: Directly passing the map of LDFs avoids the need to derive a Semantics[K].  This is easier to code.
+// TODO: Directly passing LDFs would however be more burdensome to the data scientists.
 
 /**
+  * A multi-label predictor.
   *
   * Created by ryan.deak on 8/29/17.
   *
-  * @param modelId
-  * @param labelsInTrainingSet
-  * @param labelsOfInterest
-  * @param featureNames
-  * @param featureFunctions
-  * @param predictorProducer
-  * @param auditor
+  * @param modelId An identifier for the model.  User in score and error reporting.
+  * @param featureNames feature names (parallel to featureFunctions)
+  * @param featureFunctions feature extracting functions.
+  * @param labelsInTrainingSet a sequence of all labels encountered during training. Note: the
+  *                            order of labels may relate to the predictor produced by
+  *                            predictorProducer.  It is the caller's responsibility to ensure
+  *                            the order is correct.  To mitigate such problems, both labels
+  *                            and indices into labelsInTrainingSet are passed to the predictor
+  *                            produced by predictorProducer.
+  * @param labelsOfInterest if provided, a sequence of labels will be extracted from the example
+  *                         for which a prediction is desired. The ''intersection'' of the
+  *                         extracted labels and the training labels will be the labels for which
+  *                         predictions will be produced.
+  * @param predictorProducer the function produced when calling this function is responsible for
+  *                          getting the data into the correct type and using it within an
+  *                          underlying ML library to produce a prediction.  The mapping back to
+  *                          (K, Double) pairs is also its responsibility.
+  * @param numMissingThreshold if provided, we check whether the threshold is exceeded.  If so,
+  *                            return an error instead of the computed score.  This is for missing
+  *                            data situations.
+  * @param auditor transforms a `Map[K, Double]` to a `B`.  Reports successes and errors.
   * @tparam U upper bound on model output type `B`
   * @tparam K type of label or class
   * @tparam A input type of the model
   * @tparam B output type of the model.
   */
-// TODO: When adding label-dep features, a Seq[GenAggFunc[K, Sparse]] will be needed.
-// TODO: To create a Seq[GenAggFunc[K, Sparse]], a Semantics[K] needs to be derived from a Semantics[A].
-// TODO: MorphableSemantics provides this.  If K is *embedded inside* A, it should be possible in some cases.
 case class MultilabelModel[U, K, -A, +B <: U](
     modelId: ModelIdentity,
-    labelsInTrainingSet: sci.IndexedSeq[K],
-
-    labelsOfInterest: Option[GenAggFunc[A, sci.IndexedSeq[K]]],
-
     featureNames: sci.IndexedSeq[String],
     featureFunctions: sci.IndexedSeq[GenAggFunc[A, Sparse]],
-
+    labelsInTrainingSet: sci.IndexedSeq[K],
+    labelsOfInterest: Option[GenAggFunc[A, sci.IndexedSeq[K]]],
     predictorProducer: SparsePredictorProducer[K],
-    auditor: Auditor[U, Map[K, Double], B]
-)
-extends SubmodelBase[U, Map[K, Double], A, B] {
+    numMissingThreshold: Option[Int],
+    auditor: Auditor[U, Map[K, Double], B])
+extends SubmodelBase[U, Map[K, Double], A, B]
+   with RegressionFeatures[A] {
+
   import MultilabelModel._
 
   /**
@@ -54,48 +74,31 @@ extends SubmodelBase[U, Map[K, Double], A, B] {
     * We don't care about the lazy property.  It should be created eagerly.
     */
   @transient private[this] lazy val predictor = predictorProducer()
-
-  {
-    // Force predictor eagerly
-    predictor
-  }
+  predictor // Force predictor eagerly
 
   private[this] val labelToInd: Map[K, Int] =
     labelsInTrainingSet.zipWithIndex.map { case (label, i) => label -> i }(collection.breakOut)
 
-
   override def subvalue(a: A): Subvalue[B, Map[K, Double]] = {
+    val li = labelsAndInfo(a, labelsInTrainingSet, labelsOfInterest, labelToInd)
 
-    // TODO: Is this good enough?  Are we tracking enough missing information?  Probably not.
-    val (indices, labelsToPredict, labelsWithNoPrediction) =
-      labelsOfInterest.map ( labelFn =>
-        labelsForPrediction(a, labelFn, labelToInd)
-      ) getOrElse {
-        (labelsInTrainingSet.indices, labelsInTrainingSet, Seq.empty)
+    if (li.labels.isEmpty)
+      reportNoPrediction(modelId, li, auditor)
+    else {
+      val Features(x, missing, missingOk) = constructFeatures(a)
+
+      if (!missingOk)
+        reportTooManyMissing(modelId, li, missing, auditor)
+      else {
+        // TODO: To support label-dependent features, fill last parameter with a valid value.
+        val predictionTry = Try { predictor(x, li.labels, li.indices, sci.IndexedSeq.empty) }
+
+        predictionTry match {
+          case Success(pred) => reportSuccess(modelId, li, missing, pred, auditor)
+          case Failure(ex)   => reportPredictorError(modelId, li, missing, ex, auditor)
+        }
       }
-
-    // TODO: Do a better job of tracking missing features like in the RegressionFeatures trait.
-    val features = featureFunctions.map(f => f(a))
-
-    // TODO: If labelsToPredict is empty, don't run predictor.  Return failure and report inside.
-
-    // predictor is responsible for getting the data into the correct type and applying
-    // it within the underlying ML library to produce a prediction.  The mapping back to
-    // (K, Double) pairs is also its responsibility.
-    //
-    // TODO: When supporting label-dependent features, fill in the last parameter with a valid value.
-    // TODO: Consider wrapping in a Try
-    val natural = predictor(features, labelsToPredict, indices, sci.IndexedSeq.empty)
-
-    val errors =
-      if (labelsWithNoPrediction.nonEmpty)
-        Seq(s"Labels provide for which a prediction could not be produced: ${labelsWithNoPrediction.mkString(", ")}.")
-      else Seq.empty
-
-    // TODO: Incorporate missing data reporting.
-    val aud: B = auditor.success(modelId, natural, errorMsgs = errors)
-
-    Subvalue(aud, Option(natural))
+    }
   }
 
   override def close(): Unit =
@@ -107,11 +110,156 @@ extends SubmodelBase[U, Map[K, Double], A, B] {
 
 object MultilabelModel extends ParserProviderCompanion {
 
+  /**
+    *
+    * @param indices
+    * @param labels
+    * @param missingLabels
+    * @param problems
+    * @tparam K
+    */
+  protected[multilabel] case class LabelsAndInfo[K](
+      indices: sci.IndexedSeq[Int],
+      labels: sci.IndexedSeq[K],
+      missingLabels: Seq[K],
+      problems: Option[GenAggFuncAccessorProblems]
+  )
+
+  /**
+    *
+    * @param a
+    * @param labelsInTrainingSet
+    * @param labelsOfInterest
+    * @param labelToInd
+    * @tparam A
+    * @tparam K
+    * @return
+    */
+  protected[multilabel] def labelsAndInfo[A, K](
+      a: A,
+      labelsInTrainingSet: sci.IndexedSeq[K],
+      labelsOfInterest: Option[GenAggFunc[A, sci.IndexedSeq[K]]],
+      labelToInd: Map[K, Int]
+  ): LabelsAndInfo[K] = {
+    // TODO: Is this good enough?  Are we tracking enough missing information?  Probably not.
+    labelsOfInterest.map ( labelFn =>
+      labelsForPrediction(a, labelFn, labelToInd)
+    ) getOrElse {
+      LabelsAndInfo(labelsInTrainingSet.indices, labelsInTrainingSet, Seq.empty, None)
+    }
+  }
+
+  /**
+    *
+    * @param modelId
+    * @param missing
+    * @param auditor
+    * @tparam U
+    * @tparam K
+    * @tparam B
+    * @return
+    */
+  protected[multilabel] def reportTooManyMissing[U, K, B](
+      modelId: ModelIdentity,
+      labelInfo: LabelsAndInfo[K],
+      missing: scm.Map[String, Seq[String]],
+      auditor: Auditor[U, Map[K, Double], B]
+  ): Subvalue[B, Nothing] = {
+    // TODO: Fill in the errors.
+    val aud = auditor.failure(modelId, missingVarNames = missing.values.flatten.toSet)
+    Subvalue(aud, None)
+  }
+
+  /**
+    *
+    * @param modelId
+    * @param labelInfo
+    * @param auditor
+    * @tparam U
+    * @tparam K
+    * @tparam B
+    * @return
+    */
+  protected[multilabel] def reportNoPrediction[U, K, B](
+      modelId: ModelIdentity,
+      labelInfo: LabelsAndInfo[K],
+      auditor: Auditor[U, Map[K, Double], B]
+  ): Subvalue[B, Nothing] = {
+    // TODO: Fill in the errors.
+    val aud = auditor.failure(modelId)
+    Subvalue(aud, None)
+  }
+
+  /**
+    *
+    * @param modelId
+    * @param labelInfo
+    * @param missing
+    * @param prediction
+    * @param auditor
+    * @tparam U
+    * @tparam K
+    * @tparam B
+    * @return
+    */
+  protected[multilabel] def reportSuccess[U, K, B](
+      modelId: ModelIdentity,
+      labelInfo: LabelsAndInfo[K],
+      missing: scm.Map[String, Seq[String]],
+      prediction: Map[K, Double],
+      auditor: Auditor[U, Map[K, Double], B]
+  ): Subvalue[B, Map[K, Double]] = {
+
+    val errors =
+      if (labelInfo.missingLabels.nonEmpty)
+        Seq(s"Labels provide for which a prediction could not be produced: ${labelInfo.missingLabels.mkString(", ")}.")
+      else Seq.empty
+
+    // TODO: Incorporate missing data reporting.
+    val aud: B = auditor.success(modelId, prediction, errorMsgs = errors)
+
+    Subvalue(aud, Option(prediction))
+  }
+
+  /**
+    *
+    * @param modelId
+    * @param labelInfo
+    * @param missing
+    * @param throwable
+    * @param auditor
+    * @tparam U
+    * @tparam K
+    * @tparam B
+    * @return
+    */
+  protected[multilabel] def reportPredictorError[U, K, B](
+      modelId: ModelIdentity,
+      labelInfo: LabelsAndInfo[K],
+      missing: scm.Map[String, Seq[String]],
+      throwable: Throwable,
+      auditor: Auditor[U, Map[K, Double], B]
+  ): Subvalue[B, Nothing] = {
+
+    // TODO: Fill in.
+    val aud = auditor.failure(modelId)
+    Subvalue(aud, None)
+  }
+
+  /**
+    *
+    * @param a
+    * @param labelsOfInterest
+    * @param labelToInd
+    * @tparam A
+    * @tparam K
+    * @return
+    */
   protected[multilabel] def labelsForPrediction[A, K](
       a: A,
       labelsOfInterest: GenAggFunc[A, sci.IndexedSeq[K]],
       labelToInd: Map[K, Int]
-  ): (sci.IndexedSeq[Int], sci.IndexedSeq[K], Seq[K]) = {
+  ): LabelsAndInfo[K] = {
 
     val labelsShouldPredict = labelsOfInterest(a)
 
@@ -121,14 +269,19 @@ object MultilabelModel extends ParserProviderCompanion {
         ind   <- labelToInd.get(label).toList
       } yield (ind, label)
 
+    val problems =
+      if (labelsShouldPredict.nonEmpty) None
+      else Option(labelsOfInterest.accessorOutputProblems(a))
+
     val noPrediction =
       if (unsorted.size == labelsShouldPredict.size) Seq.empty
       else labelsShouldPredict.filterNot(labelToInd.contains)
 
     val (ind, lab) = unsorted.sortBy{ case (i, _) => i }.unzip
 
-    (ind, lab, noPrediction)
+    LabelsAndInfo(ind, lab, noPrediction, problems)
   }
+
 
   override def parser: ModelParser = Parser
 
@@ -171,7 +324,6 @@ object MultilabelModel extends ParserProviderCompanion {
         // TODO: parse the feature extraction
 
         // TODO: parse the native submodel from the wrapped ML library.  This involves plugins
-
 
         ???
       }

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/MultilabelModel.scala
@@ -49,6 +49,10 @@ case class MultilabelModel[U, K, -A, +B <: U](
 extends SubmodelBase[U, Map[K, Double], A, B] {
   import MultilabelModel._
 
+  /**
+    * predictory is transient lazy value because we don't need to worry about serialization.
+    * We don't care about the lazy property.  It should be created eagerly.
+    */
   @transient private[this] lazy val predictor = predictorProducer()
 
   {

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/SerializabilityEvidence.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/SerializabilityEvidence.scala
@@ -1,0 +1,17 @@
+package com.eharmony.aloha.models.multilabel
+
+/**
+  * A type class used to indicate a parameter has a type that can be serialized in
+  * a larger Serializable object.
+  */
+sealed trait SerializabilityEvidence[A]
+
+object SerializabilityEvidence {
+
+  implicit def anyValEvidence[A <: AnyVal]: SerializabilityEvidence[A] =
+    new SerializabilityEvidence[A]{}
+
+  implicit def serializableEvidence[A <: Serializable]: SerializabilityEvidence[A] =
+    new SerializabilityEvidence[A]{}
+}
+

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -1,0 +1,64 @@
+package com.eharmony.aloha.models
+
+import com.eharmony.aloha.dataset.density.Sparse
+import scala.collection.{immutable => sci}
+
+/**
+  * Created by ryan.deak on 8/31/17.
+  */
+package object multilabel {
+
+  /**
+    * Features about the input value (NOT including features based on labels).
+    */
+  private type SparseFeatures = sci.IndexedSeq[Sparse]
+
+  /**
+    * Indices of the labels for which predictions should be produced into the
+    * sequence of all labels.  Indices will be sorted in ascending order.
+    */
+  private type LabelIndices = sci.IndexedSeq[Int]
+
+  /**
+    * Labels for which predictions should be produced.  This can be an improper subset of all labels.
+    * `Labels` align with `LabelIndices` meaning `LabelIndices[i]` will give the index of `Labels[i]`
+    * into the sequence of all labels a model knows about.
+    *
+    * @tparam K the type of labels (or classes in the machine learning literature).
+    */
+  private type Labels[K] = sci.IndexedSeq[K]
+
+  /**
+    * Features related to the labels.  Other outer sequence aligns with the `Labels` and `LabelIndices`
+    * sequences meaning `SparseLabelDepFeatures[i]` relates to the features of `Labels[i]`.
+    */
+  private type SparseLabelDepFeatures = sci.IndexedSeq[sci.IndexedSeq[Sparse]]
+
+  /**
+    * A sparse multi-label predictor takes:
+    *
+    - features
+    - labels for which a prediction should be produced
+    - indices of those labels into sequence of all of the labels the model knows about.
+    - label dependent-features
+    *
+    * and returns a Map from the labels passed in, to the prediction associated with the label.
+    *
+    * @tparam K the type of labels (or classes in the machine learning literature).
+    */
+  private type SparseMultiLabelPredictor[K] =
+    (SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]
+
+  /**
+    * A lazy version of a sparse multi-label predictor.  It is a curried zero-arg function that
+    * produces a sparse multi-label predictor.
+    *
+    * This definition is "lazy" because we can't guarantee that the underlying predictor is
+    * `Serializable` so we pass around a function that can be cached in a ''transient''
+    * `lazy val`.  This function should however be `Serializable` and testing should be done
+    * to ensure that each predictor producer is `Serializable`.
+    *
+    * @tparam K the type of labels (or classes in the machine learning literature).
+    */
+  type SparsePredictorProducer[K] = () => SparseMultiLabelPredictor[K]
+}

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -1,6 +1,9 @@
 package com.eharmony.aloha.models
 
+import java.io.Closeable
+
 import com.eharmony.aloha.dataset.density.Sparse
+
 import scala.collection.{immutable => sci}
 
 /**
@@ -47,7 +50,7 @@ package object multilabel {
     * @tparam K the type of labels (or classes in the machine learning literature).
     */
   private type SparseMultiLabelPredictor[K] =
-    (SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]
+    ((SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]) with Closeable
 
   /**
     * A lazy version of a sparse multi-label predictor.  It is a curried zero-arg function that

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -55,7 +55,7 @@ package object multilabel {
     *
     * @tparam K the type of labels (or classes in the machine learning literature).
     */
-  private[multilabel] type SparseMultiLabelPredictor[K] =
+  type SparseMultiLabelPredictor[K] =
     (SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]
 
   /**

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -29,10 +29,10 @@ package object multilabel {
   private type Labels[K] = sci.IndexedSeq[K]
 
   /**
-    * Features related to the labels.  Other outer sequence aligns with the `Labels` and `LabelIndices`
+    * Sparse features related to the labels.  Other outer sequence aligns with the `Labels` and `LabelIndices`
     * sequences meaning `SparseLabelDepFeatures[i]` relates to the features of `Labels[i]`.
     */
-  private type SparseLabelDepFeatures = sci.IndexedSeq[sci.IndexedSeq[Sparse]]
+  private type SparseLabelDepFeatures = Labels[SparseFeatures]
 
   /**
     * A sparse multi-label predictor takes:

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -49,9 +49,11 @@ package object multilabel {
     *
     * and returns a Map from the labels passed in, to the prediction associated with the label.
     *
+    * '''NOTE''': This is exposed as package private for testing.
+    *
     * @tparam K the type of labels (or classes in the machine learning literature).
     */
-  private type SparseMultiLabelPredictor[K] =
+  private[multilabel] type SparseMultiLabelPredictor[K] =
     (SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]
 
   /**

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -9,7 +9,7 @@ import scala.collection.{immutable => sci}
   */
 package object multilabel {
 
-  // All but the last type are package private, for testing.  The last is public.
+  // All but the last two types are package private, for testing.  The others are public.
 
   /**
     * Features about the input value (NOT including features based on labels).

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -1,7 +1,5 @@
 package com.eharmony.aloha.models
 
-import java.io.Closeable
-
 import com.eharmony.aloha.dataset.density.Sparse
 
 import scala.collection.{immutable => sci}
@@ -50,7 +48,7 @@ package object multilabel {
     * @tparam K the type of labels (or classes in the machine learning literature).
     */
   private type SparseMultiLabelPredictor[K] =
-    ((SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]) with Closeable
+    (SparseFeatures, Labels[K], LabelIndices, SparseLabelDepFeatures) => Map[K, Double]
 
   /**
     * A lazy version of a sparse multi-label predictor.  It is a curried zero-arg function that

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -11,8 +11,12 @@ package object multilabel {
 
   /**
     * Features about the input value (NOT including features based on labels).
+    * This should probably be a `sci.IndexedSeq[Sparse]` but `RegressionFeatures`
+    * returns a `collection.IndexedSeq` and using
+    * [[com.eharmony.aloha.models.reg.RegressionFeatures.constructFeatures]] is
+    * preferable and will provide consistent results across many model types.
     */
-  private type SparseFeatures = sci.IndexedSeq[Sparse]
+  private type SparseFeatures = IndexedSeq[Sparse]
 
   /**
     * Indices of the labels for which predictions should be produced into the

--- a/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
+++ b/aloha-core/src/main/scala/com/eharmony/aloha/models/multilabel/package.scala
@@ -9,6 +9,8 @@ import scala.collection.{immutable => sci}
   */
 package object multilabel {
 
+  // All but the last type are package private, for testing.  The last is public.
+
   /**
     * Features about the input value (NOT including features based on labels).
     * This should probably be a `sci.IndexedSeq[Sparse]` but `RegressionFeatures`
@@ -16,13 +18,13 @@ package object multilabel {
     * [[com.eharmony.aloha.models.reg.RegressionFeatures.constructFeatures]] is
     * preferable and will provide consistent results across many model types.
     */
-  private type SparseFeatures = IndexedSeq[Sparse]
+  private[multilabel] type SparseFeatures = IndexedSeq[Sparse]
 
   /**
     * Indices of the labels for which predictions should be produced into the
     * sequence of all labels.  Indices will be sorted in ascending order.
     */
-  private type LabelIndices = sci.IndexedSeq[Int]
+  private[multilabel] type LabelIndices = sci.IndexedSeq[Int]
 
   /**
     * Labels for which predictions should be produced.  This can be an improper subset of all labels.
@@ -31,13 +33,13 @@ package object multilabel {
     *
     * @tparam K the type of labels (or classes in the machine learning literature).
     */
-  private type Labels[K] = sci.IndexedSeq[K]
+  private[multilabel] type Labels[K] = sci.IndexedSeq[K]
 
   /**
     * Sparse features related to the labels.  Other outer sequence aligns with the `Labels` and `LabelIndices`
     * sequences meaning `SparseLabelDepFeatures[i]` relates to the features of `Labels[i]`.
     */
-  private type SparseLabelDepFeatures = Labels[SparseFeatures]
+  private[multilabel] type SparseLabelDepFeatures = Labels[SparseFeatures]
 
   /**
     * A sparse multi-label predictor takes:
@@ -69,3 +71,4 @@ package object multilabel {
     */
   type SparsePredictorProducer[K] = () => SparseMultiLabelPredictor[K]
 }
+

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
@@ -1,0 +1,167 @@
+package com.eharmony.aloha.models.multilabel
+
+import com.eharmony.aloha.ModelSerializationTestHelper
+import com.eharmony.aloha.audit.impl.tree.RootedTreeAuditor
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.BlockJUnit4ClassRunner
+
+/**
+  * Created by ryan.deak on 9/1/17.
+  */
+@RunWith(classOf[BlockJUnit4ClassRunner])
+class MultilabelModelTest extends ModelSerializationTestHelper {
+
+
+  // TODO: Fill in the test implementation and delete comments once done.
+
+  @Test def testSerialization(): Unit = {
+    // The name of this test needs to be exactly 'testSerialization'.  Don't change.
+    // Assuming all parameters passed to the MultilabelModel constructor are
+    // Serializable, MultilabelModel should also be Serializable.
+    //
+    // See com.eharmony.aloha.models.ConstantModelTest.testSerialization()
+
+    fail()
+  }
+
+  @Test def testModelCloseClosesPredictor(): Unit = {
+    // Make the predictorProducer passed to the constructor be a
+    //   'SparsePredictorProducer[K] with Closeable'.
+    // predictorProducer should track whether it is closed (using an AtomicBoolean or something).
+    // Call close on the MultilabelModel instance and ensure that the underlying predictor is
+    // also closed.
+
+    fail()
+  }
+
+  @Test def testLabelsOfInterestOmitted(): Unit = {
+    // Test labelsAndInfo[A, K] function.
+    //
+    // When labelsOfInterest = None, labelsAndInfo should return:
+    //   LabelsAndInfo[K](
+    //     indices = labelsInTrainingSet.indices,
+    //     labels = labelsInTrainingSet,
+    //     missingLabels = Seq.empty[K],
+    //     problems = None
+    //   )
+
+    fail()
+  }
+
+  @Test def testLabelsOfInterestProvided(): Unit = {
+    // Test labelsAndInfo[A, K] function.
+    //
+    // labelsAndInfo(a, labelsInTrainingSet, labelsOfInterest, labelToInd) ==
+    // labelsForPrediction(a, labelsOfInterest.get, labelToInd)
+
+    fail()
+  }
+
+  @Test def testReportTooManyMissing(): Unit = {
+    // Make sure Subvalue.natural == None
+    // Check the values of Subvalue.audited and make sure they are as expected.
+    // Subvalue.audited.value should be None.  Check the errors and missing values.
+
+    fail()
+  }
+
+  @Test def testReportNoPrediction(): Unit = {
+    // Make sure Subvalue.natural == None
+    // Check the values of Subvalue.audited and make sure they are as expected.
+    // Subvalue.audited.value should be None.  Check the errors and missing values.
+
+    fail()
+  }
+
+  @Test def testReportPredictorError(): Unit = {
+    // Make sure Subvalue.natural == None
+    // Check the values of Subvalue.audited and make sure they are as expected.
+    // Subvalue.audited.value should be None.  Check the errors and missing values.
+
+    fail()
+  }
+
+  @Test def testReportSuccess(): Unit = {
+    // Make sure Subvalue.natural == Some(value)
+    // Check the values of Subvalue.audited and make sure they are as expected.
+    // Subvalue.audited.value should be Some(value2).
+    // 'value' should equal 'value2'.
+    // Check the errors and missing values.
+
+    fail()
+  }
+
+  @Test def testLabelsForPredictionContainsProblemsWhenLabelsIsEmpty(): Unit = {
+    // Test this:
+    //    val problems =
+    //      if (labelsShouldPredict.nonEmpty) None
+    //      else Option(labelsOfInterest.accessorOutputProblems(a))
+
+    fail()
+  }
+
+  @Test def testLabelsForPredictionProvidesLabelsThatCantBePredicted(): Unit = {
+    // Test this:
+    //    val noPrediction =
+    //      if (unsorted.size == labelsShouldPredict.size) Seq.empty
+    //      else labelsShouldPredict.filterNot(labelToInd.contains)
+
+    fail()
+  }
+
+  @Test def testLabelsForPredictionReturnsLabelsSortedByIndex(): Unit = {
+    // Test this:
+    //    val (ind, lab) = unsorted.sortBy{ case (i, _) => i }.unzip
+
+    fail()
+  }
+
+  @Test def testSubvalueReportsNoPredictionWhenNoLabelsAreProvided(): Unit = {
+    // Test this:
+    //    if (li.labels.isEmpty)
+    //      reportNoPrediction(modelId, li, auditor)
+
+    fail()
+  }
+
+  @Test def testSubvalueReportsTooManyMissingWhenThereAreTooManyMissingFeatures(): Unit = {
+    // When the amount of missing data exceeds the threshold, reportTooManyMissing should be
+    // called and its value should be returned.  Instantiate a MultilabelModel and
+    // call apply with some missing data required by the features.
+
+    fail()
+  }
+
+  @Test def testExceptionsThrownByPredictorAreHandledGracefully(): Unit = {
+    // Create a predictorProducer that throws.  Check that the model still returns a value
+    // and that the error message is incorporated appropriately.
+
+    fail()
+  }
+
+  @Test def testSubvalueSuccess(): Unit = {
+    // Test the happy path by calling model.apply.  Check the value, missing data, and error messages.
+
+    fail()
+  }
+}
+
+object MultilabelModelTest {
+  // TODO: Use this label type and Auditor.
+
+  private type Label = String
+  private val Auditor = RootedTreeAuditor.noUpperBound[Map[Label, Double]](
+    accumulateErrors = false,
+    accumulateMissingFeatures = false
+  )
+
+// TODO: Access information returned in audited value by using the following functions:
+  //    val aud: RootedTree[Any, Map[Label, Double]] = ???
+  //    aud.modelId           // : ModelIdentity
+  //    aud.value             // : Option[Map[Label, Double]]  // Should be missing on failure.
+  //    aud.missingVarNames   // : Set[String]
+  //    aud.errorMsgs         // : Seq[String]
+  //    aud.prob              // : Option[Float]  (Shouldn't need this)
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
@@ -152,10 +152,7 @@ object MultilabelModelTest {
   // TODO: Use this label type and Auditor.
 
   private type Label = String
-  private val Auditor = RootedTreeAuditor.noUpperBound[Map[Label, Double]](
-    accumulateErrors = false,
-    accumulateMissingFeatures = false
-  )
+  private val Auditor = RootedTreeAuditor.noUpperBound[Map[Label, Double]]()
 
 // TODO: Access information returned in audited value by using the following functions:
   //    val aud: RootedTree[Any, Map[Label, Double]] = ???

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
@@ -12,7 +12,7 @@ import org.junit.runners.BlockJUnit4ClassRunner
   */
 @RunWith(classOf[BlockJUnit4ClassRunner])
 class MultilabelModelTest extends ModelSerializationTestHelper {
-
+  import MultilabelModelTest._
 
   // TODO: Fill in the test implementation and delete comments once done.
 

--- a/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/models/multilabel/MultilabelModelTest.scala
@@ -146,6 +146,12 @@ class MultilabelModelTest extends ModelSerializationTestHelper {
 
     fail()
   }
+
+  @Test def testExceptionsThrownInFeatureFunctionsAreNotCaught(): Unit = {
+    // NOTE: This is by design.
+
+    fail()
+  }
 }
 
 object MultilabelModelTest {


### PR DESCRIPTION
## NOTE

This is a slightly weird PR since this ticket is to be done in stages.  The goal is to review that stages in pieces, then I'll delete the PR and submit another for the next stage.

## Goals

This PR review should address the `MultilabelModel` **case class** and the supporting functions in the companion object (*but not `Parser` in the `MultilabelModel` companion object*).  It should also cover the `multilabel` **package object** and the `MultilabelModelTest`.

## Details

Currently, the `MultilabelModel` will not support label-dependent features.  This infrastructure should be sufficient to wrap most if not all multi-label predictors.
