### PR TITLE
Closes #197

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,11 +269,6 @@ pomExtra in Global := (
         <distribution>repo</distribution>
       </license>
     </licenses>
-    <scm>
-      <url>git@github.com:eharmony/aloha.git</url>
-      <developerConnection>scm:git:git@github.com:eharmony/aloha.git</developerConnection>
-      <connection>scm:git:git@github.com:eharmony/aloha.git</connection>
-    </scm>
     <developers>
       <developer>
         <id>deaktator</id>
@@ -283,7 +278,7 @@ pomExtra in Global := (
             <role>creator</role>
             <role>developer</role>
         </roles>
-        <timezone>-7</timezone>
+        <timezone>-8</timezone>
       </developer>
     </developers>
   )


### PR DESCRIPTION
## Summary
Removed SCM section from pom content because new sbt-git version pulled in from microsites plugin automatically adds it. Leaving it in breaks deploy.  See [https://github.com/sbt/sbt-git/pull/117](https://github.com/sbt/sbt-git/pull/117) for details.

## Resolves
* Fixes issue #197

## Side Effects
Changed developer timezone in POM

### Code Reviewer(s)
@jmorra