### PR TITLE
Closes #203

### DIFF
--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/LazyInitSupport.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/LazyInitSupport.scala
@@ -1,0 +1,52 @@
+package com.eharmony.aloha.semantics
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+  * Provides support for testing that feature functions produced by semantics
+  * do not call the feature function body when optional data is not present.
+  *
+  * This should probably be mixed into unit test companion objects.
+  *
+  * @author deaktator
+  * @since 11/28/2017
+  */
+trait LazyInitSupport {
+  private[this] val NotCalled = false
+  private[this] val Called = true
+
+  /**
+    * Only to be modified by `wasCalled`.
+    */
+  private[this] val indicator = new AtomicBoolean(NotCalled)
+
+  /**
+    * Attempt to set `indicator` to `true` assuming `indicator` wasn't already set.
+    * `true` if indicator wasn't previously set; otherwise, `false`.
+    */
+  private[this] lazy val wasCalled = indicator.compareAndSet(NotCalled, Called)
+
+  /**
+    * This function should be called in a feature function created by the
+    * semantics to test that when `a` represents optional data that is not
+    * present, the `lazy val` is not initialized.  For instance:
+    *
+    * {{{
+    * val semantics: Semantics[Option[String]] = ???
+    * val spec = "code(${missingVariable})"
+    * val default = Some(None)
+    * val f: GenAggFunc[A, Option[Boolean]] =
+    *   semantics.createFunction[Option[Boolean]](spec, default).right.get
+    * val y = f(None)
+    * assertFalse(codeWasCalled)
+    * }}}
+    * @param a some value.
+    * @return `true`, ''assuming'' `indicator` ''wasn't modified''.
+    */
+  def code(a: Any): Boolean = wasCalled
+
+  /**
+    * @return whether `code` was called.
+    */
+  def codeWasCalled: Boolean = indicator.get
+}

--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/LazyInitSupport.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/LazyInitSupport.scala
@@ -11,20 +11,20 @@ import java.util.concurrent.atomic.AtomicBoolean
   * @author deaktator
   * @since 11/28/2017
   */
-trait LazyInitSupport {
-  private[this] val NotCalled = false
-  private[this] val Called = true
+private[aloha] abstract class LazyInitSupport {
+  private val NotCalled = false
+  private val Called = true
 
   /**
     * Only to be modified by `wasCalled`.
     */
-  private[this] val indicator = new AtomicBoolean(NotCalled)
+  private val indicator = new AtomicBoolean(NotCalled)
 
   /**
     * Attempt to set `indicator` to `true` assuming `indicator` wasn't already set.
     * `true` if indicator wasn't previously set; otherwise, `false`.
     */
-  private[this] lazy val wasCalled = indicator.compareAndSet(NotCalled, Called)
+  private lazy val wasCalled = indicator.compareAndSet(NotCalled, Called)
 
   /**
     * This function should be called in a feature function created by the

--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsInstances.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsInstances.scala
@@ -3,7 +3,7 @@ package com.eharmony.aloha.semantics.compiled
 import com.eharmony.aloha.FileLocations
 import com.eharmony.aloha.reflect.RefInfo
 import com.eharmony.aloha.semantics.compiled.compiler.TwitterEvalCompiler
-import com.eharmony.aloha.semantics.compiled.plugin.AnyNameIdentitySemanticsPlugin
+import com.eharmony.aloha.semantics.compiled.plugin.{AnyNameIdentitySemanticsPlugin, AnyNameMissingValueSemanticsPlugin}
 
 /**
   * Created by ryan.deak on 9/26/17.
@@ -23,6 +23,25 @@ object CompiledSemanticsInstances {
       new TwitterEvalCompiler(classCacheDir = FileLocations.testGeneratedClasses),
       new AnyNameIdentitySemanticsPlugin[A],
       List("com.eharmony.aloha.feature.BasicFunctions._")
+    )
+  }
+
+  /**
+    * Creates a [[CompiledSemantics]] with the [[AnyNameMissingValueSemanticsPlugin]] and
+    * the supplied `imports`.  A class cache directory will be used.
+    * @param imports the imports to use.  The default is
+    *                `List("com.eharmony.aloha.feature.BasicFunctions._")`.
+    * @tparam A the domain of the functions created by this semantics.
+    * @return
+    */
+  private[aloha] def anyNameMissingValueSemantics[A: RefInfo](
+      imports: Seq[String] = List("com.eharmony.aloha.feature.BasicFunctions._")
+  )(implicit ev: A <:< Option[_]): CompiledSemantics[A] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    new CompiledSemantics(
+      new TwitterEvalCompiler(classCacheDir = FileLocations.testGeneratedClasses),
+      new AnyNameMissingValueSemanticsPlugin[A],
+      imports
     )
   }
 }

--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsTest.scala
@@ -4,9 +4,10 @@ import java.{lang => jl}
 
 import com.eharmony.aloha.FileLocations
 import com.eharmony.aloha.reflect.RefInfo
+import com.eharmony.aloha.semantics.LazyInitSupport
 import com.eharmony.aloha.semantics.compiled.compiler.TwitterEvalCompiler
-import org.junit.Assert._
 import org.junit.Test
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
 
@@ -96,6 +97,40 @@ class CompiledSemanticsTest {
     }
 
 
+    @Test
+    def testFeatureFunctionsDoNotCallReferencedFunctionsWhenDataIsMissing(): Unit = {
+        // According to the semantics, the input type must be an Option.
+        val semantics = CompiledSemanticsInstances.anyNameMissingValueSemantics[Option[String]]()
+
+        // Call the `code` function on a variable with missing data.
+        val spec = s"${getClass.getCanonicalName}.code" + "(${missingVariable})"
+
+        // The output type of the function is Option[Boolean] for two reasons:
+        //   1. the output of the `code` function in the companion object is Boolean
+        //   2. the semantics produces a GeneratedAccessor[Option[String]], therefore,
+        //      the output of the function must be an Option.  As a consequence of
+        //      having optional data, a default must be provided.  This is `Some(None)`
+        //      because the default is that when missing data is present, `f` will return
+        //      the `None` inside the `Some(None)`.
+        val default = Some(None)
+        val fAttempt = semantics.createFunction[Option[Boolean]](spec, default)
+
+        // Assert the compilation succeeded.
+        assertTrue(s"Compilation failed. Found $fAttempt", fAttempt.isRight)
+        val f = fAttempt.right.get
+
+        // Call the function with (missing) data.  It doesn't matter whether the data is
+        // missing or not because the semantics should return missing data.
+        val x = None
+        val y = f(x)
+        assertEquals(None, y)
+
+        // The `code` function should not have been called because the data wasn't present
+        // (since the semantics deleted it even if it was present).
+        val wasCalled = CompiledSemanticsTest.codeWasCalled
+        assertFalse(wasCalled)
+    }
+
     private[this] object MapStringLongPlugin extends CompiledSemanticsPlugin[Map[String, Long]] {
         def refInfoA = RefInfo[Map[String, Long]]
         def accessorFunctionCode(spec: String) = {
@@ -107,6 +142,8 @@ class CompiledSemanticsTest {
         }
     }
 }
+
+object CompiledSemanticsTest extends LazyInitSupport
 
 object StaticFuncs {
     def f(a: jl.Long): Long = if (null == a) 13 else 18

--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsTest.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/CompiledSemanticsTest.scala
@@ -112,8 +112,8 @@ class CompiledSemanticsTest {
         //      having optional data, a default must be provided.  This is `Some(None)`
         //      because the default is that when missing data is present, `f` will return
         //      the `None` inside the `Some(None)`.
-        val default = Some(None)
-        val fAttempt = semantics.createFunction[Option[Boolean]](spec, default)
+        val defaultReturnValue = Some(None)
+        val fAttempt = semantics.createFunction[Option[Boolean]](spec, defaultReturnValue)
 
         // Assert the compilation succeeded.
         assertTrue(s"Compilation failed. Found $fAttempt", fAttempt.isRight)

--- a/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/plugin/AnyNameMissingValueSemanticsPlugin.scala
+++ b/aloha-core/src/test/scala/com/eharmony/aloha/semantics/compiled/plugin/AnyNameMissingValueSemanticsPlugin.scala
@@ -1,0 +1,26 @@
+package com.eharmony.aloha.semantics.compiled.plugin
+
+import com.eharmony.aloha.reflect.{RefInfo, RefInfoOps}
+import com.eharmony.aloha.semantics.compiled.{CompiledSemanticsPlugin, OptionalAccessorCode}
+
+/**
+  * A semantics whose variables (''with any name'') always return missing data.
+  * @param refInfoA reflection information about `A`
+  * @param evOpt evidence that `A` is an `Option` of some kind.
+  * @tparam A the input type to a model (an `Option` of some kind).
+  * @author deaktator
+  * @since 11/28/2017
+  */
+private[aloha] class AnyNameMissingValueSemanticsPlugin[A](implicit
+    val refInfoA: RefInfo[A],
+    evOpt: A <:< Option[_])
+  extends CompiledSemanticsPlugin[A] {
+
+  /**
+    * Produces code for a function that takes an `Option[A]` and returns an `Option.empty[A]`.
+    * @param spec an '''ignored''' string-based specification of a function.
+    * @return
+    */
+  override def accessorFunctionCode(spec: String): Right[Nothing, OptionalAccessorCode] =
+    Right(OptionalAccessorCode(Seq(s"(o: ${RefInfoOps.toString[A]}) => o.filterNot(_ => true)")))
+}


### PR DESCRIPTION
## Summary

There was some discussion as to whether feature function bodies are only called when data is present.  While this has always been the design, I don't think there are ever a test for this.  This was added to ***ensure*** that's the case. 

## Resolves
* Provides guarantees related to #203

## Tests
See `CompiledSemanticsTest.testFeatureFunctionsDoNotCallReferencedFunctionsWhenDataIsMissing` in *aloha-core*.  Also adds support for doing a similar thing with other `CompiledSemanticsPlugin`s by creating a trait that can be mixed into test class companion objects.

## Code Reviewer(s)
@jmorra
