### PR TITLE
Closes #209

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ description := "Scala-based machine learning library with generic models and laz
 
 lazy val commonSettings = Seq(
   organization := "com.eharmony",
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.5", "2.11.8"),
+  scalaVersion := "2.11.12",
+  crossScalaVersions := Seq("2.10.5", "2.11.12"),
   crossPaths := true,
   incOptions := incOptions.value.withNameHashing(true),
   javacOptions ++= Seq("-Xlint:unchecked"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val log4jVersion = "1.2.17"
 
   val vwJniVersion = "8.4.1"
-  val h2oVersion = "3.10.3.2"
+  val h2oVersion = "3.18.0.5"
   val guavaVersion = "16.0.1"
   val avroVersion = "1.8.1"
 
@@ -45,8 +45,13 @@ object Dependencies {
 
   val vwJni = "com.github.johnlangford" % "vw-jni" % vwJniVersion
 
-  val h2o = "ai.h2o" % "h2o-core" % h2oVersion excludeAll(ExclusionRule("ai.h2o", "reflections"))
-  val h2oGenModel = "ai.h2o" % "h2o-genmodel" % h2oVersion
+  val h2o = "ai.h2o" % "h2o-core" % h2oVersion excludeAll(
+    ExclusionRule("ai.h2o", "reflections"),
+    ExclusionRule("org.slf4j", "slf4j-log4j12")
+  )
+  val h2oGenModel = "ai.h2o" % "h2o-genmodel" % h2oVersion excludeAll(
+    ExclusionRule("org.slf4j", "slf4j-log4j12")
+  )
 
   val guava = "com.google.guava" % "guava"  % guavaVersion
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.2-SNAPSHOT"
+version in ThisBuild := "5.2.0-SNAPSHOT"


### PR DESCRIPTION
## Summary

To get ready for spark 2.3.0 release, update Scala version and h2o version to compatible version used by sparkling water.

Updated 
- **Scala**: `2.11.8` -> `2.11.12`
- **H<sub>2</sub>O**: `3.10.3.2` -> `3.18.0.5`

## Resolves
* #209 

## Side Effects
Had to exclude slf4j log4j12 in `h2o-core` and `h2o-genmodel`.

## How to Verify
If it builds, everything should be fine.

### Code Reviewer(s)
@jmorra